### PR TITLE
support back quote for SHOW CREATE TABLE like SQL

### DIFF
--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/parser/clause/TableReferencesClauseParser.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/parser/clause/TableReferencesClauseParser.java
@@ -168,7 +168,7 @@ public class TableReferencesClauseParser implements SQLClauseParser {
     public final void parseSingleTableWithoutAlias(final SQLStatement sqlStatement) {
         int beginPosition = lexerEngine.getCurrentToken().getEndPosition() - lexerEngine.getCurrentToken().getLiterals().length();
         sqlStatement.getSqlTokens().add(new TableToken(beginPosition, lexerEngine.getCurrentToken().getLiterals()));
-        sqlStatement.getTables().add(new Table(lexerEngine.getCurrentToken().getLiterals(), Optional.<String>absent()));
+        sqlStatement.getTables().add(new Table(SQLUtil.getExactlyValue(lexerEngine.getCurrentToken().getLiterals()), Optional.<String>absent()));
         lexerEngine.nextToken();
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/rewrite/SQLBuilder.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/rewrite/SQLBuilder.java
@@ -102,7 +102,7 @@ public final class SQLBuilder {
                 result.append(each);
                 continue;
             }
-            String logicTableName = ((ShardingPlaceholder) each).getLogicTableName();
+            String logicTableName = ((ShardingPlaceholder) each).getLogicTableName().trim();
             String actualTableName = logicAndActualTableMap.get(logicTableName);
             if (each instanceof TablePlaceholder) {
                 result.append(null == actualTableName ? logicTableName : actualTableName);

--- a/sharding-core/src/main/java/io/shardingsphere/core/rule/ShardingRule.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/rule/ShardingRule.java
@@ -126,14 +126,15 @@ public final class ShardingRule {
      * @return table rule
      */
     public TableRule getTableRule(final String logicTableName) {
-        Optional<TableRule> tableRule = tryFindTableRuleByLogicTable(logicTableName.toLowerCase());
+        final String trimLogicTableName = logicTableName.trim();
+        Optional<TableRule> tableRule = tryFindTableRuleByLogicTable(trimLogicTableName.toLowerCase());
         if (tableRule.isPresent()) {
             return tableRule.get();
         }
         if (!Strings.isNullOrEmpty(shardingDataSourceNames.getDefaultDataSourceName())) {
-            return createTableRuleWithDefaultDataSource(logicTableName.toLowerCase());
+            return createTableRuleWithDefaultDataSource(trimLogicTableName.toLowerCase());
         }
-        throw new ShardingConfigurationException("Cannot find table rule and default data source with logic table: '%s'", logicTableName);
+        throw new ShardingConfigurationException("Cannot find table rule and default data source with logic table: '%s'", trimLogicTableName);
     }
     
     private TableRule createTableRuleWithDefaultDataSource(final String logicTableName) {


### PR DESCRIPTION
1. support back quote for SHOW CREATE TABLE like SQL
2. support SHOW COLUMNS FROM like SQL with default schema 'sharding_db'

Test cases:
SHOW COLUMNS FROM `t_order`
SHOW COLUMNS FROM `t_order` from `sharding_db`
SHOW COLUMNS FROM t_order
SHOW COLUMNS FROM t_order from `sharding_db`

SHOW COLUMNS FROM `sharding_db`.`t_order`
SHOW COLUMNS FROM `sharding_db`.`t_order` from `sharding_db`
SHOW COLUMNS FROM sharding_db.`t_order`
SHOW COLUMNS FROM sharding_db.`t_order` from `sharding_db`
SHOW COLUMNS FROM `sharding_db`.t_order
SHOW COLUMNS FROM `sharding_db`.t_order from `sharding_db`
SHOW COLUMNS FROM sharding_db.t_order
SHOW COLUMNS FROM sharding_db.t_order from `sharding_db`