### PR TITLE
use execute instead of executeQuery to get MySQL tables metadata

### DIFF
--- a/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/MySQLShardingMetaDataHandler.java
+++ b/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/MySQLShardingMetaDataHandler.java
@@ -42,7 +42,7 @@ public final class MySQLShardingMetaDataHandler extends ShardingMetaDataHandler 
     @Override
     public boolean isTableExist(final Connection connection) throws SQLException {
         try (Statement statement = connection.createStatement()) {
-            statement.executeQuery(String.format("show tables like '%s'", getActualTableName()));
+            statement.execute(String.format("show tables like '%s'", getActualTableName()));
             try (ResultSet resultSet = statement.getResultSet()) {
                 return resultSet.next();
             }
@@ -53,7 +53,7 @@ public final class MySQLShardingMetaDataHandler extends ShardingMetaDataHandler 
     public List<ColumnMetaData> getExistColumnMeta(final Connection connection) throws SQLException {
         List<ColumnMetaData> result = new LinkedList<>();
         try (Statement statement = connection.createStatement()) {
-            statement.executeQuery(String.format("desc %s;", getActualTableName()));
+            statement.execute(String.format("desc %s;", getActualTableName()));
             try (ResultSet resultSet = statement.getResultSet()) {
                 while (resultSet.next()) {
                     result.add(new ColumnMetaData(resultSet.getString("Field"), resultSet.getString("Type"), resultSet.getString("Key")));


### PR DESCRIPTION
Hi!

I was playing around with your library (looks great!) using c3p0 as underlying thread pool, and after upgrading from 2.0.3 to 3.0.0.M1 I got the following error when using `ShardingDataSourceFactory.createDataSource`:
```
java.lang.InternalError: Marking a ResultSet inactive that we did not know was opened!
	at com.mchange.v2.c3p0.impl.NewPooledConnection.markInactiveResultSetForStatement(NewPooledConnection.java:353)
	at com.mchange.v2.c3p0.impl.NewProxyResultSet.close(NewProxyResultSet.java:844)
	at com.mchange.v2.c3p0.impl.NewProxyStatement.close(NewProxyStatement.java:162)
	at io.shardingsphere.core.jdbc.metadata.dialect.MySQLShardingMetaDataHandler.isTableExist(MySQLShardingMetaDataHandler.java:49)
	at io.shardingsphere.core.jdbc.metadata.dialect.ShardingMetaDataHandler.getColumnMetaDataList(ShardingMetaDataHandler.java:55)
	at io.shardingsphere.core.jdbc.metadata.JDBCShardingMetaData.getColumnMetaDataList(JDBCShardingMetaData.java:57)
	at io.shardingsphere.core.metadata.ShardingMetaData.getTableMetaData(ShardingMetaData.java:88)
	at io.shardingsphere.core.metadata.ShardingMetaData.refresh(ShardingMetaData.java:81)
	at io.shardingsphere.core.metadata.ShardingMetaData.refresh(ShardingMetaData.java:69)
	at io.shardingsphere.core.metadata.ShardingMetaData.init(ShardingMetaData.java:57)
	at io.shardingsphere.core.jdbc.core.datasource.ShardingDataSource.<init>(ShardingDataSource.java:66)
	at io.shardingsphere.core.api.ShardingDataSourceFactory.createDataSource(ShardingDataSourceFactory.java:51)
```
After a bit of research I found that using `execute` instead of `executeQuery` to retrieve the MySQL tables metadata could solve the issue, and it actually did the job to me.

Sorry for the cold approach, if you have any collaboration guidelines I didn't find them.

Cheers!

## Changes proposed in this pull request:
- Use `execute` instead of `executeQuery` in `MySQLShardingMetaDataHandler`
