### PR TITLE
 fix cloud orchestration could't get shardingDatasource correctly.

### DIFF
--- a/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/OrchestrationShardingDataSourceFactoryBean.java
+++ b/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/OrchestrationShardingDataSourceFactoryBean.java
@@ -69,6 +69,9 @@ public class OrchestrationShardingDataSourceFactoryBean implements FactoryBean<O
     
     private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
         Map<String, DataSource> result = new LinkedHashMap<>();
+        if (null == dataSourceMap) {
+            return result;
+        }
         for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             String dataSourceName = entry.getKey();
             DataSource dataSource = entry.getValue();
@@ -83,6 +86,9 @@ public class OrchestrationShardingDataSourceFactoryBean implements FactoryBean<O
     
     private static ShardingRuleConfiguration getShardingRuleConfiguration(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
         Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
+        if (null == dataSourceMap) {
+            return shardingRuleConfig;
+        }
         for (DataSource each : dataSourceMap.values()) {
             if (!(each instanceof MasterSlaveDataSource)) {
                 continue;

--- a/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/OrchestrationShardingDataSourceFactoryBean.java
+++ b/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/OrchestrationShardingDataSourceFactoryBean.java
@@ -17,10 +17,7 @@
 
 package io.shardingsphere.jdbc.orchestration.spring.datasource;
 
-import io.shardingsphere.core.api.config.MasterSlaveRuleConfiguration;
 import io.shardingsphere.core.api.config.ShardingRuleConfiguration;
-import io.shardingsphere.core.jdbc.core.datasource.MasterSlaveDataSource;
-import io.shardingsphere.core.rule.MasterSlaveRule;
 import io.shardingsphere.jdbc.orchestration.api.OrchestrationShardingDataSourceFactory;
 import io.shardingsphere.jdbc.orchestration.api.config.OrchestrationConfiguration;
 import io.shardingsphere.jdbc.orchestration.internal.OrchestrationShardingDataSource;
@@ -29,16 +26,13 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 
 import javax.sql.DataSource;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
 
 /**
  * Orchestration sharding data source factory bean.
- * 
- * @author zhangliang 
+ *
+ * @author zhangliang
  */
 public class OrchestrationShardingDataSourceFactoryBean implements FactoryBean<OrchestrationShardingDataSource>, InitializingBean, DisposableBean {
     
@@ -61,44 +55,10 @@ public class OrchestrationShardingDataSourceFactoryBean implements FactoryBean<O
     public OrchestrationShardingDataSourceFactoryBean(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig,
                                                       final Map<String, Object> configMap, final Properties props, final OrchestrationConfiguration orchestrationConfig) {
         this.orchestrationConfig = orchestrationConfig;
-        this.dataSourceMap = getRawDataSourceMap(dataSourceMap);
-        this.shardingRuleConfig = getShardingRuleConfiguration(dataSourceMap, shardingRuleConfig);
+        this.dataSourceMap = dataSourceMap;
+        this.shardingRuleConfig = shardingRuleConfig;
         this.configMap = configMap;
         this.props = props;
-    }
-    
-    private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
-        Map<String, DataSource> result = new LinkedHashMap<>();
-        if (null == dataSourceMap) {
-            return result;
-        }
-        for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            String dataSourceName = entry.getKey();
-            DataSource dataSource = entry.getValue();
-            if (dataSource instanceof MasterSlaveDataSource) {
-                result.putAll(((MasterSlaveDataSource) dataSource).getAllDataSources());
-            } else {
-                result.put(dataSourceName, dataSource);
-            }
-        }
-        return result;
-    }
-    
-    private static ShardingRuleConfiguration getShardingRuleConfiguration(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
-        Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
-        if (null == dataSourceMap) {
-            return shardingRuleConfig;
-        }
-        for (DataSource each : dataSourceMap.values()) {
-            if (!(each instanceof MasterSlaveDataSource)) {
-                continue;
-            }
-            MasterSlaveRule masterSlaveRule = ((MasterSlaveDataSource) each).getMasterSlaveRule();
-            masterSlaveRuleConfigs.add(new MasterSlaveRuleConfiguration(
-                    masterSlaveRule.getName(), masterSlaveRule.getMasterDataSourceName(), masterSlaveRule.getSlaveDataSourceNames(), masterSlaveRule.getLoadBalanceAlgorithm()));
-        }
-        shardingRuleConfig.setMasterSlaveRuleConfigs(masterSlaveRuleConfigs);
-        return shardingRuleConfig;
     }
     
     @Override
@@ -118,7 +78,7 @@ public class OrchestrationShardingDataSourceFactoryBean implements FactoryBean<O
     
     @Override
     public void afterPropertiesSet() throws Exception {
-        orchestrationShardingDataSource = 
+        orchestrationShardingDataSource =
                 (OrchestrationShardingDataSource) OrchestrationShardingDataSourceFactory.createDataSource(dataSourceMap, shardingRuleConfig, configMap, props, orchestrationConfig);
     }
     

--- a/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/SpringShardingDataSource.java
@@ -17,18 +17,12 @@
 
 package io.shardingsphere.jdbc.orchestration.spring.datasource;
 
-import io.shardingsphere.core.api.config.MasterSlaveRuleConfiguration;
 import io.shardingsphere.core.api.config.ShardingRuleConfiguration;
-import io.shardingsphere.core.jdbc.core.datasource.MasterSlaveDataSource;
 import io.shardingsphere.core.jdbc.core.datasource.ShardingDataSource;
-import io.shardingsphere.core.rule.MasterSlaveRule;
 import io.shardingsphere.core.rule.ShardingRule;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
 
@@ -41,40 +35,6 @@ public class SpringShardingDataSource extends ShardingDataSource {
     
     public SpringShardingDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig,
                                     final Map<String, Object> configMap, final Properties props) throws SQLException {
-        super(getRawDataSourceMap(dataSourceMap), new ShardingRule(addMasterSlaveRuleConfigurations(dataSourceMap, shardingRuleConfig), dataSourceMap.keySet()), configMap, props);
-    }
-    
-    private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
-        Map<String, DataSource> result = new LinkedHashMap<>();
-        if (null == dataSourceMap) {
-            return result;
-        }
-        for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            String dataSourceName = entry.getKey();
-            DataSource dataSource = entry.getValue();
-            if (dataSource instanceof MasterSlaveDataSource) {
-                result.putAll(((MasterSlaveDataSource) dataSource).getAllDataSources());
-            } else {
-                result.put(dataSourceName, dataSource);
-            }
-        }
-        return result;
-    }
-    
-    private static ShardingRuleConfiguration addMasterSlaveRuleConfigurations(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
-        Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
-        if (null == dataSourceMap) {
-            return shardingRuleConfig;
-        }
-        for (DataSource each : dataSourceMap.values()) {
-            if (!(each instanceof MasterSlaveDataSource)) {
-                continue;
-            }
-            MasterSlaveRule masterSlaveRule = ((MasterSlaveDataSource) each).getMasterSlaveRule();
-            masterSlaveRuleConfigs.add(new MasterSlaveRuleConfiguration(
-                    masterSlaveRule.getName(), masterSlaveRule.getMasterDataSourceName(), masterSlaveRule.getSlaveDataSourceNames(), masterSlaveRule.getLoadBalanceAlgorithm()));
-        }
-        shardingRuleConfig.setMasterSlaveRuleConfigs(masterSlaveRuleConfigs);
-        return shardingRuleConfig;
+        super(getRawDataSourceMap(dataSourceMap), new ShardingRule(getShardingRuleConfiguration(dataSourceMap, shardingRuleConfig), dataSourceMap.keySet()), configMap, props);
     }
 }

--- a/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-namespace/src/main/java/io/shardingsphere/jdbc/orchestration/spring/datasource/SpringShardingDataSource.java
@@ -46,6 +46,9 @@ public class SpringShardingDataSource extends ShardingDataSource {
     
     private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
         Map<String, DataSource> result = new LinkedHashMap<>();
+        if (null == dataSourceMap) {
+            return result;
+        }
         for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             String dataSourceName = entry.getKey();
             DataSource dataSource = entry.getValue();
@@ -60,6 +63,9 @@ public class SpringShardingDataSource extends ShardingDataSource {
     
     private static ShardingRuleConfiguration addMasterSlaveRuleConfigurations(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
         Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
+        if (null == dataSourceMap) {
+            return shardingRuleConfig;
+        }
         for (DataSource each : dataSourceMap.values()) {
             if (!(each instanceof MasterSlaveDataSource)) {
                 continue;

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/internal/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/internal/OrchestrationShardingDataSource.java
@@ -47,10 +47,10 @@ public class OrchestrationShardingDataSource extends ShardingDataSource {
     
     public OrchestrationShardingDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig,
                                            final Map<String, Object> configMap, final Properties props, final OrchestrationFacade orchestrationFacade) throws SQLException {
-        super(dataSourceMap, new ShardingRule(shardingRuleConfig, dataSourceMap.keySet()), configMap, props);
+        super(getRawDataSourceMap(dataSourceMap), new ShardingRule(getShardingRuleConfiguration(dataSourceMap, shardingRuleConfig), getRawDataSourceMap(dataSourceMap).keySet()), configMap, props);
         this.orchestrationFacade = orchestrationFacade;
-        this.dataSourceMap = dataSourceMap;
-        this.shardingRuleConfig = shardingRuleConfig;
+        this.dataSourceMap = getRawDataSourceMap(dataSourceMap);
+        this.shardingRuleConfig = getShardingRuleConfiguration(dataSourceMap, shardingRuleConfig);
         this.configMap = configMap;
         this.props = props;
     }

--- a/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/io/shardingsphere/jdbc/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/io/shardingsphere/jdbc/spring/datasource/SpringShardingDataSource.java
@@ -17,20 +17,13 @@
 
 package io.shardingsphere.jdbc.spring.datasource;
 
-import io.shardingsphere.core.api.config.MasterSlaveRuleConfiguration;
 import io.shardingsphere.core.api.config.ShardingRuleConfiguration;
-import io.shardingsphere.core.jdbc.core.datasource.MasterSlaveDataSource;
 import io.shardingsphere.core.jdbc.core.datasource.ShardingDataSource;
-import io.shardingsphere.core.rule.MasterSlaveRule;
 import io.shardingsphere.core.rule.ShardingRule;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 
 /**
@@ -41,42 +34,8 @@ import java.util.Properties;
  */
 public class SpringShardingDataSource extends ShardingDataSource {
     
-    public SpringShardingDataSource(final Map<String, DataSource> dataSourceMap, 
+    public SpringShardingDataSource(final Map<String, DataSource> dataSourceMap,
                                     final ShardingRuleConfiguration shardingRuleConfig, final Map<String, Object> configMap, final Properties props) throws SQLException {
-        super(getRawDataSourceMap(dataSourceMap), new ShardingRule(addMasterSlaveRuleConfigurations(dataSourceMap, shardingRuleConfig), dataSourceMap.keySet()), configMap, props);
-    }
-    
-    private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
-        Map<String, DataSource> result = new LinkedHashMap<>();
-        if (null == dataSourceMap) {
-            return result;
-        }
-        for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            String dataSourceName = entry.getKey();
-            DataSource dataSource = entry.getValue();
-            if (dataSource instanceof MasterSlaveDataSource) {
-                result.putAll(((MasterSlaveDataSource) dataSource).getAllDataSources());
-            } else {
-                result.put(dataSourceName, dataSource);
-            }
-        }
-        return result;
-    }
-    
-    private static ShardingRuleConfiguration addMasterSlaveRuleConfigurations(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
-        Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
-        if (null == dataSourceMap) {
-            return shardingRuleConfig;
-        }
-        for (DataSource each : dataSourceMap.values()) {
-            if (!(each instanceof MasterSlaveDataSource)) {
-                continue;
-            }
-            MasterSlaveRule masterSlaveRule = ((MasterSlaveDataSource) each).getMasterSlaveRule();
-            masterSlaveRuleConfigs.add(new MasterSlaveRuleConfiguration(
-                    masterSlaveRule.getName(), masterSlaveRule.getMasterDataSourceName(), masterSlaveRule.getSlaveDataSourceNames(), masterSlaveRule.getLoadBalanceAlgorithm()));
-        }
-        shardingRuleConfig.setMasterSlaveRuleConfigs(masterSlaveRuleConfigs);
-        return shardingRuleConfig;
+        super(getRawDataSourceMap(dataSourceMap), new ShardingRule(getShardingRuleConfiguration(dataSourceMap, shardingRuleConfig), dataSourceMap.keySet()), configMap, props);
     }
 }

--- a/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/io/shardingsphere/jdbc/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/io/shardingsphere/jdbc/spring/datasource/SpringShardingDataSource.java
@@ -48,6 +48,9 @@ public class SpringShardingDataSource extends ShardingDataSource {
     
     private static Map<String, DataSource> getRawDataSourceMap(final Map<String, DataSource> dataSourceMap) {
         Map<String, DataSource> result = new LinkedHashMap<>();
+        if (null == dataSourceMap) {
+            return result;
+        }
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             String dataSourceName = entry.getKey();
             DataSource dataSource = entry.getValue();
@@ -62,6 +65,9 @@ public class SpringShardingDataSource extends ShardingDataSource {
     
     private static ShardingRuleConfiguration addMasterSlaveRuleConfigurations(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig) {
         Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = new LinkedList<>();
+        if (null == dataSourceMap) {
+            return shardingRuleConfig;
+        }
         for (DataSource each : dataSourceMap.values()) {
             if (!(each instanceof MasterSlaveDataSource)) {
                 continue;


### PR DESCRIPTION

- fix cloud orchestration could't get shardingDatasource correctly.
- move getRawDataSourceMap and getMasterSlaveConfiguration static method to      ShardingDataSource for common using.