### PR TITLE
Optimize the metadata initialization

### DIFF
--- a/sharding-core/src/main/java/io/shardingsphere/core/metadata/ShardingMetaData.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/metadata/ShardingMetaData.java
@@ -17,6 +17,11 @@
 
 package io.shardingsphere.core.metadata;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.shardingsphere.core.exception.ShardingException;
 import io.shardingsphere.core.rule.DataNode;
 import io.shardingsphere.core.rule.ShardingDataSourceNames;
@@ -24,14 +29,20 @@ import io.shardingsphere.core.rule.ShardingRule;
 import io.shardingsphere.core.rule.TableRule;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract Sharding metadata.
@@ -41,9 +52,20 @@ import java.util.Map;
  */
 @Getter
 @Setter
-public abstract class ShardingMetaData {
+@Slf4j
+public abstract class ShardingMetaData implements AutoCloseable {
 
+    private static final ThreadPoolExecutor THREAD_POOL_EXECUTOR = new ThreadPoolExecutor(
+            Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().availableProcessors(), 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(), new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Sharding-JDBC-%d").build());
+    
+    private final ListeningExecutorService executorService;
+    
     private Map<String, TableMetaData> tableMetaDataMap;
+    
+    public ShardingMetaData() {
+        executorService = MoreExecutors.listeningDecorator(THREAD_POOL_EXECUTOR);
+        MoreExecutors.addDelayedShutdownHook(executorService, 60, TimeUnit.SECONDS);
+    }
 
     /**
      * Initialize sharding metadata.
@@ -78,24 +100,39 @@ public abstract class ShardingMetaData {
      * @throws SQLException SQL exception
      */
     public void refresh(final TableRule each, final ShardingRule shardingRule, final Map<String, Connection> connectionMap) throws SQLException {
-        tableMetaDataMap.put(each.getLogicTable(), getTableMetaData(each.getLogicTable(), each.getActualDataNodes(), shardingRule.getShardingDataSourceNames(), connectionMap));
+        tableMetaDataMap.put(each.getLogicTable(), getFinalTableMetaData(each.getLogicTable(), each.getActualDataNodes(), shardingRule.getShardingDataSourceNames(), connectionMap));
     }
 
-    private TableMetaData getTableMetaData(final String logicTableName, final List<DataNode> actualDataNodes,
-                                           final ShardingDataSourceNames shardingDataSourceNames, final Map<String, Connection> connectionMap) throws SQLException {
-        Collection<ColumnMetaData> result = null;
-        for (DataNode each : actualDataNodes) {
-            Collection<ColumnMetaData> columnMetaDataList = getColumnMetaDataList(each, shardingDataSourceNames, connectionMap);
-            if (null == result) {
-                result = columnMetaDataList;
+    private TableMetaData getFinalTableMetaData(final String logicTableName, final List<DataNode> actualDataNodes,
+                                                final ShardingDataSourceNames shardingDataSourceNames, final Map<String, Connection> connectionMap) throws SQLException {
+        List<TableMetaData> actualTableMetaDataList = getAllActualTableMetaData(actualDataNodes, shardingDataSourceNames, connectionMap);
+        for (int i = 0; i < actualTableMetaDataList.size(); i++) {
+            if (actualTableMetaDataList.size() - 1 == i) {
+                return actualTableMetaDataList.get(i);
             }
-            if (!result.equals(columnMetaDataList)) {
-                throw new ShardingException(getErrorMsgOfTableMetaData(logicTableName, each, columnMetaDataList));
+            if (!actualTableMetaDataList.get(i).equals(actualTableMetaDataList.get(i + 1))) {
+                throw new ShardingException(getErrorMsgOfTableMetaData(logicTableName, actualTableMetaDataList.get(i), actualTableMetaDataList.get(i + 1)));
             }
         }
-        return new TableMetaData(result);
+        return new TableMetaData(new ArrayList<ColumnMetaData>());
     }
-
+    
+    private List<TableMetaData> getAllActualTableMetaData(final List<DataNode> actualDataNodes, final ShardingDataSourceNames shardingDataSourceNames, final Map<String, Connection> connectionMap) throws SQLException {
+        List<ListenableFuture<TableMetaData>> result = new ArrayList<>();
+        for (final DataNode each : actualDataNodes) {
+            result.add(executorService.submit(new Callable<TableMetaData>() {
+                public TableMetaData call() throws Exception {
+                    return getTableMetaData(each, shardingDataSourceNames, connectionMap);
+                }
+            }));
+        }
+        try {
+            return Futures.allAsList(result).get();
+        } catch (final InterruptedException | ExecutionException ex) {
+            throw new ShardingException(ex);
+        }
+    }
+    
     /**d
      * Get column metadata implementing by concrete handler.
      *
@@ -105,17 +142,33 @@ public abstract class ShardingMetaData {
      * @return ColumnMetaData
      * @throws SQLException SQL exception
      */
-    public abstract Collection<ColumnMetaData> getColumnMetaDataList(DataNode dataNode, ShardingDataSourceNames shardingDataSourceNames, Map<String, Connection> connectionMap) throws SQLException;
+    public abstract TableMetaData getTableMetaData(DataNode dataNode, ShardingDataSourceNames shardingDataSourceNames, Map<String, Connection> connectionMap) throws SQLException;
 
-    private String getErrorMsgOfTableMetaData(final String logicTableName, final DataNode dataNode, final Collection<ColumnMetaData> newColumnMetaDataList) {
+    private String getErrorMsgOfTableMetaData(final String logicTableName, final TableMetaData oldTableMetaData, final TableMetaData newTableMetaData) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(" Cannot get uniformed table structure for ").append(logicTableName).append(".");
-        stringBuilder.append("The different column metadata of actual table is as follows:");
-        for (ColumnMetaData each : newColumnMetaDataList) {
-            stringBuilder.append(each.toString()).append(" ");
-        }
-        stringBuilder.append(" The problem dataNode is: ");
-        stringBuilder.append(dataNode.toString());
+        stringBuilder.append("The different metadata of actual tables is as follows:");
+        stringBuilder.append(oldTableMetaData.toString());
+        stringBuilder.append("\n");
+        stringBuilder.append(newTableMetaData.toString());
         return stringBuilder.toString();
+    }
+    
+    @Override
+    public void close() {
+        THREAD_POOL_EXECUTOR.execute(new Runnable() {
+            
+            @Override
+            public void run() {
+                try {
+                    executorService.shutdown();
+                    while (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+                        executorService.shutdownNow();
+                    }
+                } catch (final InterruptedException ex) {
+                    log.error("ExecutorEngine can not been terminated", ex);
+                }
+            }
+        });
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/metadata/TableMetaData.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/metadata/TableMetaData.java
@@ -20,6 +20,7 @@ package io.shardingsphere.core.metadata;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
+@ToString
 public final class TableMetaData {
     
     private final Collection<ColumnMetaData> columnMetaData;

--- a/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/JDBCShardingMetaData.java
+++ b/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/JDBCShardingMetaData.java
@@ -18,8 +18,8 @@
 package io.shardingsphere.core.jdbc.metadata;
 
 import io.shardingsphere.core.constant.DatabaseType;
-import io.shardingsphere.core.metadata.ColumnMetaData;
 import io.shardingsphere.core.metadata.ShardingMetaData;
+import io.shardingsphere.core.metadata.TableMetaData;
 import io.shardingsphere.core.rule.DataNode;
 import io.shardingsphere.core.rule.ShardingDataSourceNames;
 import io.shardingsphere.core.rule.ShardingRule;
@@ -29,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -48,13 +47,13 @@ public final class JDBCShardingMetaData extends ShardingMetaData {
     private final DatabaseType databaseType;
 
     @Override
-    public Collection<ColumnMetaData> getColumnMetaDataList(final DataNode dataNode, final ShardingDataSourceNames shardingDataSourceNames,
-                                                            final Map<String, Connection> connectionMap) throws SQLException {
+    public TableMetaData getTableMetaData(final DataNode dataNode, final ShardingDataSourceNames shardingDataSourceNames,
+                                          final Map<String, Connection> connectionMap) throws SQLException {
         String dataSourceName = shardingDataSourceNames.getRawMasterDataSourceName(dataNode.getDataSourceName());
         if (connectionMap.containsKey(dataSourceName)) {
-            return ShardingMetaDataHandlerFactory.newInstance(dataNode.getTableName(), databaseType).getColumnMetaDataList(connectionMap.get(dataSourceName));
+            return ShardingMetaDataHandlerFactory.newInstance(dataNode.getTableName(), databaseType).getTableMetaData(connectionMap.get(dataSourceName));
         } else {
-            return ShardingMetaDataHandlerFactory.newInstance(dataSourceMap.get(dataSourceName), dataNode.getTableName(), databaseType).getColumnMetaDataList();
+            return ShardingMetaDataHandlerFactory.newInstance(dataSourceMap.get(dataSourceName), dataNode.getTableName(), databaseType).getTableMetaData();
         }
     }
 }

--- a/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/ShardingMetaDataHandler.java
+++ b/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/ShardingMetaDataHandler.java
@@ -18,6 +18,7 @@
 package io.shardingsphere.core.jdbc.metadata.dialect;
 
 import io.shardingsphere.core.metadata.ColumnMetaData;
+import io.shardingsphere.core.metadata.TableMetaData;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,7 @@ import lombok.RequiredArgsConstructor;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,34 +44,32 @@ public abstract class ShardingMetaDataHandler {
     private final String actualTableName;
 
     /**
-     * Get column meta data list.
+     * Get table meta data.
      *
-     * @return column meta data list
+     * @return table meta data
      * @throws SQLException SQL exception
      */
-    public Collection<ColumnMetaData> getColumnMetaDataList() throws SQLException {
-        List<ColumnMetaData> result = new LinkedList<>();
+    public TableMetaData getTableMetaData() throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             if (isTableExist(connection)) {
-                result = getExistColumnMeta(connection);
+                return new TableMetaData(getExistColumnMeta(connection));
             }
         }
-        return result;
+        return new TableMetaData(new ArrayList<ColumnMetaData>());
     }
 
     /**
-     * Get column metadata by Sharding Connection.
+     * Get table metadata by Sharding Connection.
      *
      * @param connection connection
-     * @return column metadata List
+     * @return table metadata
      * @throws SQLException SQL exception
      */
-    public Collection<ColumnMetaData> getColumnMetaDataList(final Connection connection) throws SQLException {
-        List<ColumnMetaData> result = new LinkedList<>();
+    public TableMetaData getTableMetaData(final Connection connection) throws SQLException {
         if (isTableExist(connection)) {
-            result = getExistColumnMeta(connection);
+            return new TableMetaData(getExistColumnMeta(connection));
         }
-        return result;
+        return new TableMetaData(new ArrayList<ColumnMetaData>());
     }
 
     /**

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ProxyShardingMetaData.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ProxyShardingMetaData.java
@@ -17,8 +17,8 @@
 
 package io.shardingsphere.proxy.metadata;
 
-import io.shardingsphere.core.metadata.ColumnMetaData;
 import io.shardingsphere.core.metadata.ShardingMetaData;
+import io.shardingsphere.core.metadata.TableMetaData;
 import io.shardingsphere.core.rule.DataNode;
 import io.shardingsphere.core.rule.ShardingDataSourceNames;
 import lombok.Getter;
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -42,9 +41,9 @@ public final class ProxyShardingMetaData extends ShardingMetaData {
     private final Map<String, DataSource> dataSourceMap;
     
     @Override
-    public Collection<ColumnMetaData> getColumnMetaDataList(final DataNode dataNode, final ShardingDataSourceNames shardingDataSourceNames,
-                                                            final Map<String, Connection> connectionMap) throws SQLException {
-        return new ShardingMetaDataHandler(dataSourceMap.get(shardingDataSourceNames.getRawMasterDataSourceName(dataNode.getDataSourceName())), dataNode.getTableName()).getColumnMetaDataList();
+    public TableMetaData getTableMetaData(final DataNode dataNode, final ShardingDataSourceNames shardingDataSourceNames,
+                                          final Map<String, Connection> connectionMap) throws SQLException {
+        return new ShardingMetaDataHandler(dataSourceMap.get(shardingDataSourceNames.getRawMasterDataSourceName(dataNode.getDataSourceName())), dataNode.getTableName()).getTableMetaData();
     }
 }
 

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ShardingMetaDataHandler.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ShardingMetaDataHandler.java
@@ -18,6 +18,7 @@
 package io.shardingsphere.proxy.metadata;
 
 import io.shardingsphere.core.metadata.ColumnMetaData;
+import io.shardingsphere.core.metadata.TableMetaData;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +27,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -48,16 +50,16 @@ public final class ShardingMetaDataHandler {
      * @return column meta data list
      * @throws SQLException SQL exception
      */
-    public List<ColumnMetaData> getColumnMetaDataList() throws SQLException {
-        List<ColumnMetaData> result = new LinkedList<>();
+    public TableMetaData getTableMetaData() throws SQLException {
         try (Connection connection = getDataSource().getConnection();
              Statement statement = connection.createStatement()) {
             if (isTableExist(statement)) {
-                result = getExistColumnMeta(statement);
+                return new TableMetaData(getExistColumnMeta(statement));
             }
-            return result;
+            return new TableMetaData(new ArrayList<ColumnMetaData>());
         }
     }
+    
 
     private boolean isTableExist(final Statement statement) throws SQLException {
         statement.executeQuery(String.format("show tables like '%s'", getActualTableName()));

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ShardingMetaDataHandler.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/metadata/ShardingMetaDataHandler.java
@@ -45,9 +45,9 @@ public final class ShardingMetaDataHandler {
     private final String actualTableName;
     
     /**
-     * Get column meta data list.
+     * Get table meta data.
      *
-     * @return column meta data list
+     * @return table meta data
      * @throws SQLException SQL exception
      */
     public TableMetaData getTableMetaData() throws SQLException {


### PR DESCRIPTION
Fixes #879.

Changes proposed in this pull request:
- Using threadPool to optimize metadata initialization.
- Rewrite getColumnMetaDataList to getTableMetadata.
-
