### PR TITLE
new zk client use native zk

### DIFF
--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/internal/OrchestrationFacade.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/internal/OrchestrationFacade.java
@@ -31,6 +31,7 @@ import io.shardingsphere.jdbc.orchestration.reg.api.RegistryCenter;
 import io.shardingsphere.jdbc.orchestration.reg.api.RegistryCenterConfiguration;
 import io.shardingsphere.jdbc.orchestration.reg.etcd.EtcdConfiguration;
 import io.shardingsphere.jdbc.orchestration.reg.etcd.EtcdRegistryCenter;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.NewZookeeperRegistryCenter;
 import io.shardingsphere.jdbc.orchestration.reg.zookeeper.ZookeeperConfiguration;
 import io.shardingsphere.jdbc.orchestration.reg.zookeeper.ZookeeperRegistryCenter;
 import lombok.Getter;
@@ -76,12 +77,20 @@ public final class OrchestrationFacade implements AutoCloseable {
     private RegistryCenter createRegistryCenter(final RegistryCenterConfiguration regCenterConfig) {
         Preconditions.checkNotNull(regCenterConfig, "Registry center configuration cannot be null.");
         if (regCenterConfig instanceof ZookeeperConfiguration) {
-            return new ZookeeperRegistryCenter((ZookeeperConfiguration) regCenterConfig);
+            return getZookeeperRegistryCenter((ZookeeperConfiguration) regCenterConfig);
         }
         if (regCenterConfig instanceof EtcdConfiguration) {
             return new EtcdRegistryCenter((EtcdConfiguration) regCenterConfig);
         }
         throw new UnsupportedOperationException(regCenterConfig.getClass().getName());
+    }
+    
+    private RegistryCenter getZookeeperRegistryCenter(final ZookeeperConfiguration regCenterConfig) {
+        if (regCenterConfig.isUseNative()) {
+            return new NewZookeeperRegistryCenter(regCenterConfig);
+        } else {
+            return new ZookeeperRegistryCenter(regCenterConfig);
+        }
     }
     
     /**

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import io.shardingsphere.jdbc.orchestration.reg.api.RegistryCenter;
+import io.shardingsphere.jdbc.orchestration.reg.exception.RegExceptionHandler;
+import io.shardingsphere.jdbc.orchestration.reg.listener.DataChangedEvent;
+import io.shardingsphere.jdbc.orchestration.reg.listener.EventListener;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache.PathTree;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.StringUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.ClientFactory;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.StrategyType;
+import io.shardingsphere.jdbc.orchestration.reg.zookeeper.ZookeeperConfiguration;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.ZooDefs;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Zookeeper native based registry center.
+ * 
+ * @author lidongbo
+ */
+public final class NewZookeeperRegistryCenter implements RegistryCenter {
+    
+    private final IClient client;
+    
+    private final Map<String, PathTree> caches = new HashMap<>();
+    
+    public NewZookeeperRegistryCenter(final ZookeeperConfiguration zkConfig) {
+        ClientFactory creator = buildCreator(zkConfig);
+        client = initClient(creator, zkConfig);
+    }
+    
+    private ClientFactory buildCreator(final ZookeeperConfiguration zkConfig) {
+        ClientFactory creator = new ClientFactory();
+        creator.setClientNamespace(zkConfig.getNamespace())
+                .newClient(zkConfig.getServerLists(), zkConfig.getSessionTimeoutMilliseconds())
+                .setRetryPolicy(new DelayRetryPolicy(zkConfig.getBaseSleepTimeMilliseconds(), zkConfig.getMaxRetries(), zkConfig.getMaxSleepTimeMilliseconds()));
+        if (!Strings.isNullOrEmpty(zkConfig.getDigest())) {
+            creator.authorization("digest", zkConfig.getDigest().getBytes(Charsets.UTF_8), ZooDefs.Ids.CREATOR_ALL_ACL);
+        }
+        return creator;
+    }
+    
+    private IClient initClient(final ClientFactory creator, final ZookeeperConfiguration zkConfig) {
+        IClient newClient = null;
+        try {
+            newClient = creator.start();
+            // block, slowly
+            if (!newClient.blockUntilConnected(zkConfig.getMaxSleepTimeMilliseconds() * zkConfig.getMaxRetries(), TimeUnit.MILLISECONDS)) {
+                newClient.close();
+                throw new KeeperException.OperationTimeoutException();
+            }
+            newClient.useExecStrategy(StrategyType.SYNC_RETRY);
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(e);
+        }
+        return newClient;
+    }
+    
+    @Override
+    public String get(final String key) {
+        PathTree cache = findTreeCache(key);
+        if (null == cache) {
+            return getDirectly(key);
+        }
+        byte[] resultInCache = cache.getValue(key);
+        if (null != resultInCache) {
+            return null == resultInCache ? null : new String(resultInCache, Charsets.UTF_8);
+        }
+        return getDirectly(key);
+    }
+    
+    private PathTree findTreeCache(final String key) {
+        for (Entry<String, PathTree> entry : caches.entrySet()) {
+            if (key.startsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+    
+    @Override
+    public String getDirectly(final String key) {
+        try {
+            return new String(client.getData(key), Charsets.UTF_8);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+            return null;
+        }
+    }
+    
+    @Override
+    public boolean isExisted(final String key) {
+        try {
+            return client.checkExists(key);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+            return false;
+        }
+    }
+    
+    @Override
+    public List<String> getChildrenKeys(final String key) {
+        try {
+            List<String> result = client.getChildren(key);
+            Collections.sort(result, new Comparator<String>() {
+                
+                @Override
+                public int compare(final String o1, final String o2) {
+                    return o2.compareTo(o1);
+                }
+            });
+            return result;
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+            return Collections.emptyList();
+        }
+    }
+    
+    @Override
+    public void persist(final String key, final String value) {
+        try {
+            if (!isExisted(key)) {
+                client.createAllNeedPath(key, value, CreateMode.PERSISTENT);
+            } else {
+                update(key, value);
+            }
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+        }
+    }
+    
+    @Override
+    public void update(final String key, final String value) {
+        try {
+            client.transaction().check(key, -1).setData(key, value.getBytes(Charsets.UTF_8)).commit();
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+        }
+    }
+    
+    @Override
+    public void persistEphemeral(final String key, final String value) {
+        try {
+            if (isExisted(key)) {
+                client.deleteAllChildren(key);
+            }
+            client.createAllNeedPath(key, value, CreateMode.EPHEMERAL);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+        }
+    }
+    
+    @Override
+    public void watch(final String key, final EventListener eventListener) {
+        final String path = key + "/";
+        if (!caches.containsKey(path)) {
+            addCacheData(key);
+        }
+        PathTree cache = caches.get(path);
+        cache.watch(new Listener() {
+            @Override
+            public void process(final WatchedEvent event) {
+                if (!StringUtil.isNullOrBlank(event.getPath())) {
+                    eventListener.onChange(new DataChangedEvent(getEventType(event), event.getPath(), getWithoutCache(event.getPath())));
+                }
+            }
+            
+            private DataChangedEvent.Type getEventType(final WatchedEvent event) {
+                switch (event.getType()) {
+                    case NodeDataChanged:
+                    case NodeChildrenChanged:
+                        return DataChangedEvent.Type.UPDATED;
+                    case NodeDeleted:
+                        return DataChangedEvent.Type.DELETED;
+                    default:
+                        return DataChangedEvent.Type.IGNORED;
+                }
+            }
+        });
+    }
+    
+    private synchronized String getWithoutCache(final String key) {
+        try {
+            client.useExecStrategy(StrategyType.USUAL);
+            byte[] data = client.getData(key);
+            client.useExecStrategy(StrategyType.SYNC_RETRY);
+            return null == data ? null : new String(data, Charsets.UTF_8);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+            return null;
+        }
+    }
+    
+    private void addCacheData(final String cachePath) {
+        PathTree cache = new PathTree(cachePath, client);
+        try {
+            cache.load();
+            cache.watch();
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            RegExceptionHandler.handleException(ex);
+        }
+        caches.put(cachePath + "/", cache);
+    }
+    
+    @Override
+    public void close() {
+        for (Entry<String, PathTree> each : caches.entrySet()) {
+            each.getValue().close();
+        }
+        client.close();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/Callback.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/Callback.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+/*
+ * @author lidongbo
+ */
+public interface Callback {
+    
+    /**
+    * process callback result.
+    */
+    void processResult();
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IAction.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IAction.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+
+import java.util.List;
+
+/*
+ * @author lidongbo
+ */
+public interface IAction {
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @return data String
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    String getDataString(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @return data
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    byte[] getData(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @param callback callback
+     * @param ctx ctx
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void getData(String key, AsyncCallback.DataCallback callback, Object ctx) throws KeeperException, InterruptedException;
+    
+    /**
+     * check exist.
+     *
+     * @param key key
+     * @return exist
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    boolean checkExists(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * check exist.
+     *
+     * @param key key
+     * @param watcher watcher
+     * @return exist
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    boolean checkExists(String key, Watcher watcher) throws KeeperException, InterruptedException;
+    
+    /**
+     * get children's keys.
+     *
+     * @param key key
+     * @return children keys
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    List<String> getChildren(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * only create target node.
+     *
+     * @param key key
+     * @param value value
+     * @param createMode createMode
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void createCurrentOnly(String key, String value, CreateMode createMode) throws KeeperException, InterruptedException;
+    
+    /**
+     * update.
+     *
+     * @param key key
+     * @param value value
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void update(String key, String value) throws KeeperException, InterruptedException;
+    
+    /**
+     * only delete target node..
+     *
+     * @param key key
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void deleteOnlyCurrent(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * only delete target node..
+     *
+     * @param key key
+     * @param callback callback
+     * @param ctx ctx
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void deleteOnlyCurrent(String key, AsyncCallback.VoidCallback callback, Object ctx) throws KeeperException, InterruptedException;
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.StrategyType;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction.ZKTransaction;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * client api
+ *
+ * @author lidongbo
+ */
+public interface IClient extends IAction, IGroupAction {
+    
+    /**
+     * start.
+     *
+     * @throws IOException IO Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void start() throws IOException, InterruptedException;
+    
+    /**
+     * block until connected.
+     *
+     * @param wait wait
+     * @param units units
+     * @return connected
+     * @throws InterruptedException InterruptedException
+     */
+    boolean blockUntilConnected(int wait, TimeUnit units) throws InterruptedException;
+    
+    /**
+     * close.
+     */
+    void close();
+    
+    /**
+     * register watcher.
+     *
+     * @param key key
+     * @param listener listener
+     */
+    void registerWatch(String key, Listener listener);
+    
+    /**
+     * unregister watcher.
+     *
+     * @param key key
+     */
+    void unregisterWatch(String key);
+    
+    /**
+     * choice exec strategy.
+     *
+     * @param strategyType strategyType
+     */
+    void useExecStrategy(StrategyType strategyType);
+    
+    /**
+     * create transaction.
+     *
+     * @return ZKTransaction
+     */
+    ZKTransaction transaction();
+    /*
+    void createNamespace();
+    void deleteNamespace();
+    
+    Watcher registerWatch(Listener listener);
+    void setRootNode(String namespace);
+    
+    void setAuthorities(String scheme, byte[] auth);
+    ZooKeeper getZooKeeper();
+    */
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IExecStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IExecStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+/*
+ * @author lidongbo
+ */
+public interface IExecStrategy extends IAction, IGroupAction {
+    
+    /**
+     * get provider.
+     *
+     * @return IProvider
+     */
+    IProvider getProvider();
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IGroupAction.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IGroupAction.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * @author lidongbo
+ */
+public interface IGroupAction {
+    
+    /**
+     * create target node and all need created.
+     *
+     * @param key key
+     * @param value value
+     * @param createMode createMode
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void createAllNeedPath(String key, String value, CreateMode createMode) throws KeeperException, InterruptedException;
+    
+    /**
+     * delete target node and children nodes.
+     *
+     * @param key key
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void deleteAllChildren(String key) throws KeeperException, InterruptedException;
+    
+    /**
+    * delete the current node with force and delete the super node whose only child node is current node recursively.
+     *
+     * @param key key
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+    */
+    void deleteCurrentBranch(String key) throws KeeperException, InterruptedException;
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IProvider.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IProvider.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.action;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.election.LeaderElection;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction.ZKTransaction;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+
+import java.util.List;
+import java.util.Stack;
+
+/*
+ * provider api
+ *
+ * @author lidongbo
+ */
+public interface IProvider {
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @return data String
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    String getDataString(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @return data
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    byte[] getData(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * get string type data.
+     *
+     * @param key key
+     * @param callback callback
+     * @param ctx ctx
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void getData(String key, AsyncCallback.DataCallback callback, Object ctx) throws KeeperException, InterruptedException;
+    
+    /**
+     * check exist.
+     *
+     * @param key key
+     * @return exist
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    boolean exists(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * check exist.
+     *
+     * @param key key
+     * @param watcher watcher
+     * @return exist
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    boolean exists(String key, Watcher watcher) throws KeeperException, InterruptedException;
+    
+    /**
+     * get children's keys.
+     *
+     * @param key key
+     * @return exist
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    List<String> getChildren(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * only create target node.
+     *
+     * @param key key
+     * @param value value
+     * @param createMode createMode
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void create(String key, String value, CreateMode createMode) throws KeeperException, InterruptedException;
+    
+    /**
+     * update.
+     *
+     * @param key key
+     * @param value value
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void update(String key, String value) throws KeeperException, InterruptedException;
+    
+    /**
+     * only delete target node..
+     *
+     * @param key key
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void delete(String key) throws KeeperException, InterruptedException;
+    
+    /**
+     * only delete target node..
+     *
+     * @param key key
+     * @param callback callback
+     * @param ctx ctx
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void delete(String key, AsyncCallback.VoidCallback callback, Object ctx) throws KeeperException, InterruptedException;
+    
+    /**
+     * get real path with root.
+     *
+     * @param path path
+     * @return real path
+     */
+    String getRealPath(String path);
+    
+    /**
+     * get path nodes that needed create.
+     *
+     * @param key key
+     * @return all path nodes
+     */
+    List<String> getNecessaryPaths(String key);
+    
+    /**
+     * get path nodes that needed delete.
+     *
+     * @param key key
+     * @return all path nodes
+     */
+    Stack<String> getDeletingPaths(String key);
+    
+    /**
+     * contention exec.
+     *
+     * @param election election
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void executeContention(LeaderElection election) throws KeeperException, InterruptedException;
+    
+    /**
+     * only create target node.
+     *
+     * @param key key
+     * @param value value
+     * @param createMode createMode
+     * @param transaction transaction
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    void createInTransaction(String key, String value, CreateMode createMode, ZKTransaction transaction) throws KeeperException, InterruptedException;
+    
+    /**
+     * reset connection.
+     */
+    void resetConnection();
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/CacheStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/CacheStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache;
+
+/*
+ * @author lidongbo
+ */
+public enum CacheStrategy {
+    NONE,
+    WATCH,
+    ALL
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathNode.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathNode.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import lombok.Getter;
+import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * zookeeper node cache
+ *
+ * @author lidongbo
+ */
+public class PathNode {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PathNode.class);
+
+    private final Map<String, PathNode> children = new ConcurrentHashMap<>();
+
+    private final String nodeKey;
+
+    @Getter
+    @Setter
+    private byte[] value;
+    
+    PathNode(final String key) {
+        this(key, Constants.RELEASE_VALUE);
+    }
+    
+    PathNode(final String key, final byte[] value) {
+        this.nodeKey = key;
+        this.value = value;
+    }
+    
+    /**
+     * get children.
+     *
+     * @return children
+     */
+    public Map<String, PathNode> getChildren() {
+        return children;
+    }
+    
+    /**
+     * get key.
+     *
+     * @return node key
+     */
+    public String getKey() {
+        return this.nodeKey;
+    }
+    
+    /**
+     * attach child node.
+     *
+     * @param node node
+     */
+    public void attachChild(final PathNode node) {
+        this.children.put(node.nodeKey, node);
+    }
+    
+    PathNode set(final Iterator<String> iterator, final String value) {
+        String key = iterator.next();
+        LOGGER.debug("PathNode set:{},value:{}", key, value);
+        PathNode node = children.get(key);
+        if (node == null) {
+            LOGGER.debug("set children haven't:{}", key);
+            node = new PathNode(key);
+            children.put(key, node);
+        }
+        if (iterator.hasNext()) {
+            node.set(iterator, value);
+        } else {
+            node.setValue(value.getBytes(Constants.UTF_8));
+        }
+        return node;
+    }
+    
+    PathNode get(final Iterator<String> iterator) {
+        String key = iterator.next();
+        LOGGER.debug("get:{}", key);
+        PathNode node = children.get(key);
+        if (node == null) {
+            LOGGER.debug("get children haven't:{}", key);
+            return null;
+        }
+        if (iterator.hasNext()) {
+            return node.get(iterator);
+        }
+        return node;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathStatus.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache;
+
+/*
+ * @author lidongbo
+ */
+public enum PathStatus {
+    CHANGING,
+    RELEASE
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.UsualClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.common.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+/*
+ * zookeeper cache tree
+ *
+ * @author lidongbo
+ */
+public final class PathTree {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PathTree.class);
+    
+    private final transient ReentrantLock lock = new ReentrantLock();
+    
+    private final AtomicReference<PathNode> rootNode = new AtomicReference<>();
+    
+    private boolean executorStart;
+    
+    private ScheduledExecutorService cacheService;
+    
+    private final IClient client;
+    
+    private final IProvider provider;
+    
+    @Getter
+    @Setter
+    private PathStatus status;
+    
+    private boolean closed;
+    
+    public PathTree(final String root, final IClient client) {
+        this.rootNode.set(new PathNode(root));
+        this.status = PathStatus.RELEASE;
+        this.client = client;
+        // todo It looks unpleasant
+        this.provider = ((UsualClient) client).getStrategy().getProvider();
+    }
+    
+    /**
+     * load data.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public void load() throws KeeperException, InterruptedException {
+        final ReentrantLock lock = this.lock;
+        lock.lockInterruptibly();
+        if (closed) {
+            return;
+        }
+        try {
+            if (status == status.RELEASE) {
+                LOGGER.debug("loading status:{}", status);
+                this.setStatus(PathStatus.CHANGING);
+        
+                PathNode newRoot = new PathNode(rootNode.get().getKey());
+                List<String> children = provider.getChildren(rootNode.get().getKey());
+                children.remove(PathUtil.getRealPath(rootNode.get().getKey(), Constants.CHANGING_KEY));
+                this.attechIntoNode(children, newRoot);
+                rootNode.set(newRoot);
+        
+                this.setStatus(PathStatus.RELEASE);
+//                watch();
+                LOGGER.debug("loading release:{}", status);
+            } else {
+                LOGGER.info("loading but cache status not release");
+                try {
+                    Thread.sleep(10L);
+                } catch (InterruptedException e) {
+                    LOGGER.error("loading sleep error:{}", e.getMessage(), e);
+                }
+                load();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    private void attechIntoNode(final List<String> children, final PathNode pathNode) throws KeeperException, InterruptedException {
+        if (closed) {
+            return;
+        }
+        LOGGER.debug("attechIntoNode children:{}", children);
+        if (children.isEmpty()) {
+            LOGGER.info("attechIntoNode there are no children");
+            return;
+        }
+        for (String child : children) {
+            String childPath = PathUtil.getRealPath(pathNode.getKey(), child);
+            PathNode current = new PathNode(PathUtil.checkPath(child), provider.getData(childPath));
+            pathNode.attachChild(current);
+            List<String> subs = provider.getChildren(childPath);
+            this.attechIntoNode(subs, current);
+        }
+    }
+    
+    /**
+     * start thread pool period load data.
+     *
+     * @param period period
+     */
+    public void refreshPeriodic(final long period) {
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        if (closed) {
+            return;
+        }
+        try {
+            if (executorStart) {
+                throw new IllegalArgumentException("period already set");
+            }
+            long threadPeriod = period;
+            if (threadPeriod < 1) {
+                threadPeriod = Constants.THREAD_PERIOD;
+            }
+            LOGGER.debug("refreshPeriodic:{}", period);
+            cacheService = Executors.newSingleThreadScheduledExecutor();
+            cacheService.scheduleAtFixedRate(new Runnable() {
+                @Override
+                public void run() {
+                    LOGGER.debug("cacheService run:{}", getStatus());
+                    if (PathStatus.RELEASE == getStatus()) {
+                        try {
+                            load();
+                            // CHECKSTYLE:OFF
+                        } catch (Exception e) {
+                            // CHECKSTYLE:ON
+                            LOGGER.error(e.getMessage(), e);
+                        }
+                    }
+                }
+            }, Constants.THREAD_INITIAL_DELAY, threadPeriod, TimeUnit.MILLISECONDS);
+            executorStart = true;
+            Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    stopRefresh();
+                }
+            }));
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /**
+     * stop thread pool period load data.
+     */
+    public void stopRefresh() {
+        cacheService.shutdown();
+        executorStart = false;
+        LOGGER.debug("stopRefresh");
+    }
+    
+    /**
+     * watch data change.
+     */
+    public void watch() {
+        watch(new Listener(rootNode.get().getKey()) {
+            @Override
+            public void process(final WatchedEvent event) {
+                String path = event.getPath();
+                LOGGER.debug("PathTree Watch event:{}", event.toString());
+                switch (event.getType()) {
+                    case NodeCreated:
+                    case NodeDataChanged:
+                    case NodeChildrenChanged:
+                        processNodeChange(path);
+                        break;
+                    case NodeDeleted:
+                        delete(path);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        });
+    }
+    
+    /**
+     * watch data change.
+     *
+     * @param listener listener
+     */
+    public void watch(final Listener listener) {
+        if (closed) {
+            return;
+        }
+        final String key = listener.getKey();
+        LOGGER.debug("PathTree Watch:{}", key);
+        client.registerWatch(rootNode.get().getKey(), listener);
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                LOGGER.debug("PathTree Unregister Watch:{}", key);
+                client.unregisterWatch(key);
+            }
+        }));
+    }
+    
+    private void processNodeChange(final String path) {
+        try {
+            String value = Constants.NOTHING_VALUE;
+            if (!path.equals(getRootNode().getKey())) {
+                value = provider.getDataString(path);
+            }
+            put(path, value);
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            // CHECKSTYLE:ON
+            LOGGER.error("PathTree put error : " + e.getMessage());
+        }
+    }
+    
+    /**
+     * get root node.
+     *
+     * @return root node
+     */
+    public PathNode getRootNode() {
+        return rootNode.get();
+    }
+    
+    /**
+     * get node value.
+     *
+     * @param path path
+     * @return node data
+     */
+    public byte[] getValue(final String path) {
+        if (closed) {
+            return null;
+        }
+        PathNode node = get(path);
+        return null == node ? null : node.getValue();
+    }
+    
+    private Iterator<String> keyIterator(final String path) {
+        List<String> nodes = PathUtil.getShortPathNodes(path);
+        LOGGER.debug("keyIterator path{},nodes:{}", path, nodes);
+        Iterator<String> iterator = nodes.iterator();
+        // root
+        iterator.next();
+        return iterator;
+    }
+    
+    /**
+     * get children.
+     *
+     * @param path path
+     * @return children
+     */
+    public List<String> getChildren(final String path) {
+        if (closed) {
+            return null;
+        }
+        PathNode node = get(path);
+        List<String> result = new ArrayList<>();
+        if (node == null) {
+            LOGGER.info("getChildren null");
+            return result;
+        }
+        if (node.getChildren().isEmpty()) {
+            LOGGER.info("getChildren no child");
+            return result;
+        }
+        Iterator<PathNode> children = node.getChildren().values().iterator();
+        while (children.hasNext()) {
+            result.add(new String(children.next().getValue()));
+        }
+        return result;
+    }
+    
+    private PathNode get(final String path) {
+        LOGGER.debug("PathTree get:{}", path);
+        PathUtils.validatePath(path);
+        if (path.equals(rootNode.get().getKey())) {
+            return rootNode.get();
+        }
+        Iterator<String> iterator = keyIterator(path);
+        if (iterator.hasNext()) {
+            return rootNode.get().get(iterator);
+        }
+        LOGGER.debug("{} not exist", path);
+        return null;
+    }
+    
+    /**
+     * put node.
+     *
+     * @param path path
+     * @param value value
+     */
+    public void put(final String path, final String value) {
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        if (closed) {
+            return;
+        }
+        try {
+            LOGGER.debug("cache put:{},value:{}", path, value);
+            PathUtils.validatePath(path);
+            LOGGER.debug("put status:{}", status);
+            if (status == status.RELEASE) {
+                if (path.equals(rootNode.get().getKey())) {
+                    rootNode.set(new PathNode(rootNode.get().getKey(), value.getBytes(Constants.UTF_8)));
+                    return;
+                }
+                this.setStatus(PathStatus.CHANGING);
+                rootNode.get().set(keyIterator(path), value);
+                this.setStatus(PathStatus.RELEASE);
+            } else {
+                try {
+                    LOGGER.debug("put but cache status not release");
+                    Thread.sleep(10L);
+                } catch (InterruptedException e) {
+                    LOGGER.error("put sleep error:{}", e.getMessage(), e);
+                }
+                put(path, value);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /**
+     * delete node.
+     *
+     * @param path path
+     */
+    public void delete(final String path) {
+        LOGGER.debug("PathTree begin delete:{}", path);
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        if (closed) {
+            return;
+        }
+        try {
+            PathUtils.validatePath(path);
+//            String prxpath = path.substring(0, path.lastIndexOf(Constants.PATH_SEPARATOR));
+            PathNode node = get(path);
+            node.getChildren().remove(path);
+            LOGGER.debug("PathTree end delete:{}", path);
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    /**
+     * close.
+     */
+    public void close() {
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        this.closed = true;
+        try {
+            if (executorStart) {
+                stopRefresh();
+            }
+            deleteAllChildren(rootNode.get());
+            // CHECKSTYLE:OFF
+        } catch (Exception ee){
+            // CHECKSTYLE:ON
+            LOGGER.warn("PathTree close:{}", ee.getMessage());
+        } finally {
+            lock.unlock();
+        }
+    }
+    
+    private void deleteAllChildren(final PathNode node) {
+        if (node.getChildren().isEmpty()) {
+            return;
+        }
+        for (String one : node.getChildren().keySet()) {
+            deleteAllChildren(node.getChildren().get(one));
+            node.getChildren().remove(one);
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/election/LeaderElection.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/election/LeaderElection.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.election;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.WatcherCreator;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * competition of node write permission
+ * It is not recommended to be used as a global variable.
+ *
+ * @author lidongbo
+ */
+public abstract class LeaderElection {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaderElection.class);
+    
+    private boolean done;
+    
+    private int retryCount;
+    
+    public LeaderElection() {
+        retryCount = Constants.NODE_ELECTION_RETRY;
+    }
+
+    private boolean contend(final String node, final IProvider provider, final Listener listener) throws KeeperException, InterruptedException {
+        boolean success = false;
+        try {
+            // todo EPHEMERAL_SEQUENTIAL check index value
+            provider.create(node, Constants.CLIENT_ID, CreateMode.EPHEMERAL);
+            success = true;
+        } catch (KeeperException.NodeExistsException e) {
+            LOGGER.info("contend not success");
+            // TODO or changing_key node value == current client id
+            provider.exists(node, WatcherCreator.deleteWatcher(listener));
+        }
+        return success;
+    }
+    
+    /**
+     * listener will be register when the contention of the path is unsuccessful.
+     *
+     * @param nodeBeContend nodeBeContend
+     * @param provider provider
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+    */
+    public void executeContention(final String nodeBeContend, final IProvider provider) throws KeeperException, InterruptedException {
+        boolean canBegin;
+        final String realNode = provider.getRealPath(nodeBeContend);
+        final String contendNode = PathUtil.getRealPath(realNode, Constants.CHANGING_KEY);
+        canBegin = this.contend(contendNode, provider, new Listener(contendNode) {
+            @Override
+            public void process(final WatchedEvent event) {
+                try {
+                    retryCount--;
+                    if (retryCount < 0) {
+                        LOGGER.info("Election node exceed retry count");
+                        return;
+                    }
+                    executeContention(realNode, provider);
+                    // CHECKSTYLE:OFF
+                } catch (Exception ee){
+                    // CHECKSTYLE:ON
+                    LOGGER.error("Listener Exception executeContention:{}", ee.getMessage(), ee);
+                }
+            }
+        });
+    
+        if (canBegin) {
+            try {
+                action();
+                done = true;
+                callback();
+                // CHECKSTYLE:OFF
+            } catch (Exception e){
+                // CHECKSTYLE:ON
+                LOGGER.error("action Exception executeContention:{}", e.getMessage(), e);
+            }
+            provider.delete(contendNode);
+        }
+    }
+    
+    /**
+     * wait done.
+     */
+    public void waitDone() {
+        while (!done) {
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException e) {
+                LOGGER.error("waitDone:{}", e.getMessage(), e);
+            }
+        }
+    }
+    
+    /**
+     * contend exec.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public abstract void action() throws KeeperException, InterruptedException;
+    
+    /**
+     * callback.
+     */
+    public void callback() {
+        
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/AsyncRetryCenter.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/AsyncRetryCenter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.DelayQueue;
+
+/*
+ * async retry center
+ *
+ * @author lidongbo
+ */
+public enum AsyncRetryCenter {
+    INSTANCE;
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncRetryCenter.class);
+    
+    private final DelayQueue<BaseOperation> queue = new DelayQueue<>();
+    
+    private final RetryThread retryThread = new RetryThread(queue);
+    
+    private boolean started;
+    
+    private DelayRetryPolicy delayRetryPolicy;
+    
+    /**
+     * init.
+     *
+     * @param delayRetryPolicy delayRetryPolicy
+     */
+    public void init(final DelayRetryPolicy delayRetryPolicy) {
+        LOGGER.debug("delayRetryPolicy init");
+        if (delayRetryPolicy == null) {
+            LOGGER.warn("delayRetryPolicy is null and auto init with DelayRetryPolicy.newNoInitDelayPolicy");
+            this.delayRetryPolicy = DelayRetryPolicy.newNoInitDelayPolicy();
+        }
+        this.delayRetryPolicy = delayRetryPolicy;
+    }
+    
+    /**
+     * start.
+     */
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+        retryThread.setName("retry-thread");
+        retryThread.start();
+        this.started = true;
+    }
+    
+    /**
+     * add async operation.
+     *
+     * @param operation operation
+     */
+    public void add(final BaseOperation operation) {
+        if (delayRetryPolicy == null) {
+            LOGGER.warn("delayRetryPolicy no init and auto init with DelayRetryPolicy.newNoInitDelayPolicy");
+            delayRetryPolicy = DelayRetryPolicy.newNoInitDelayPolicy();
+        }
+        operation.setDelayPolicyExecutor(new DelayPolicyExecutor(delayRetryPolicy));
+        queue.offer(operation);
+        LOGGER.debug("enqueue operation:{}", operation.toString());
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/DelayPolicyExecutor.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/DelayPolicyExecutor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+/*
+ * delay policy executor
+ *
+ * @author lidongbo
+ */
+public class DelayPolicyExecutor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DelayPolicyExecutor.class);
+    
+    private final DelayRetryPolicy delayRetryPolicy;
+    
+    private final Random random;
+    
+    private int executeCount;
+    
+    private long executeTick;
+    
+    public DelayPolicyExecutor() {
+        this(DelayRetryPolicy.newNoInitDelayPolicy());
+    }
+    
+    public DelayPolicyExecutor(final DelayRetryPolicy delayRetryPolicy) {
+        this.delayRetryPolicy = delayRetryPolicy;
+        this.executeTick = System.currentTimeMillis();
+        this.random = new Random();
+//        next();
+    }
+    
+    /**
+     * has next.
+     *
+     * @return has next
+     */
+    public boolean hasNext() {
+        return executeCount < delayRetryPolicy.getRetryCount();
+    }
+    
+    /**
+     * next exec tick.
+     *
+     * @return next exec tick
+     */
+    public long getNextTick() {
+        return executeTick;
+    }
+    
+    /**
+     * next.
+     */
+    public void next() {
+        executeCount++;
+        long sleep = delayRetryPolicy.getBaseDelay() * Math.max(1, this.random.nextInt(1 << delayRetryPolicy.getRetryCount() + 1));
+        if (sleep < delayRetryPolicy.getDelayUpperBound()) {
+            executeTick += sleep;
+        } else {
+            executeTick += delayRetryPolicy.getDelayUpperBound();
+        }
+        LOGGER.debug("next executeCount:{}, executeTick:{}", executeCount, executeTick);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/DelayRetryPolicy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/DelayRetryPolicy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import lombok.Getter;
+
+/*
+ * delay policy
+ *
+ * @author lidongbo
+ */
+public class DelayRetryPolicy {
+    private static final long BASE_DELAY = 10;
+    
+    private static final int BASE_COUNT = 3;
+    
+    private static final int RETRY_COUNT_BOUND = 29;
+    
+    @Getter
+    private final int retryCount;
+    
+    @Getter
+    private final long baseDelay;
+    
+    @Getter
+    private final long delayUpperBound;
+    
+    /*
+    * Millis
+    */
+    public DelayRetryPolicy(final long baseDelay) {
+        this(RETRY_COUNT_BOUND, baseDelay, Integer.MAX_VALUE);
+    }
+    
+    public DelayRetryPolicy(final int retryCount, final long baseDelay, final long delayUpperBound) {
+        this.retryCount = retryCount;
+        this.baseDelay = baseDelay;
+        this.delayUpperBound = delayUpperBound;
+    }
+    
+    /**
+     * default DelayPolicy.
+     *
+     * @return DelayPolicy
+     */
+    public static DelayRetryPolicy newNoInitDelayPolicy() {
+        return new DelayRetryPolicy(BASE_COUNT, BASE_DELAY, Integer.MAX_VALUE);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryThread.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryThread.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class RetryThread extends Thread {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetryThread.class);
+    
+    private final int corePoolSize = Runtime.getRuntime().availableProcessors();
+    
+    private final ThreadPoolExecutor retryExecutor;
+    
+    private final int maximumPoolSize = corePoolSize;
+    
+    private final long keepAliveTime = 0;
+    
+    private final int closeDelay = 60;
+    
+    private final DelayQueue<BaseOperation> queue;
+    
+    public RetryThread(final DelayQueue<BaseOperation> queue) {
+        this.queue = queue;
+        retryExecutor = new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(10), new ThreadFactory() {
+            private final AtomicInteger threadIndex = new AtomicInteger(0);
+            @Override
+            public Thread newThread(final Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setDaemon(true);
+                thread.setName("zk-retry-" + threadIndex.incrementAndGet());
+                LOGGER.debug("new thread:{}", thread.getName());
+                return thread;
+            }
+        });
+        addDelayedShutdownHook(retryExecutor, closeDelay, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void run() {
+        LOGGER.debug("RetryThread start");
+        for (;;) {
+            final BaseOperation operation;
+            try {
+                operation = queue.take();
+                LOGGER.debug("take operation:{}", operation.toString());
+            } catch (InterruptedException e) {
+                LOGGER.error("retry interrupt e:{}", e.getMessage());
+                continue;
+            }
+            retryExecutor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    boolean result;
+                    try {
+                        result = operation.executeOperation();
+                        // CHECKSTYLE:OFF
+                    } catch (Exception e) {
+                        // CHECKSTYLE:ON
+                        result = false;
+                        LOGGER.error("retry disrupt operation:{}, e:{}", operation.toString(), e.getMessage());
+                    }
+                    if (result) {
+                        queue.offer(operation);
+                        LOGGER.debug("enqueue again operation:{}", operation.toString());
+                    }
+                }
+            });
+        }
+    }
+    
+    final void addDelayedShutdownHook(final ExecutorService service, final long terminationTimeout, final TimeUnit timeUnit) {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    LOGGER.debug("AsyncRetryCenter stop");
+                    queue.clear();
+                    service.shutdown();
+                    service.awaitTermination(terminationTimeout, timeUnit);
+                } catch (InterruptedException ignored) {
+                    // shutting down anyway, just ignore.
+                }
+            }
+        });
+        thread.setName("retry shutdown hook");
+        Runtime.getRuntime().addShutdownHook(thread);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/Constants.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/Constants.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility;
+
+import java.nio.charset.Charset;
+
+/*
+ * constants
+ *
+ * @author lidongbo
+ */
+public final class Constants {
+    public static final int VERSION = -1;
+    
+    public static final int WAIT = 60 * 1000;
+    
+    public static final byte[] NOTHING_DATA = new byte[0];
+    
+    public static final String NOTHING_VALUE = "";
+    
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    
+    public static final String PATH_SEPARATOR = "/";
+    
+    public static final String GLOBAL_LISTENER_KEY = "globalListener";
+    
+    public static final byte[] CHANGING_VALUE = new byte[]{'c'};
+    
+    public static final byte[] RELEASE_VALUE = new byte[]{'r'};
+    
+    public static final String CHANGING_KEY = "CHANGING_KEY";
+    
+    public static final long THREAD_PERIOD = 3000L;
+    
+    public static final long THREAD_INITIAL_DELAY = 1000L;
+    
+    public static final int NODE_ELECTION_RETRY = 3;
+    
+    public static final String CLIENT_ID = "1";
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/PathUtil.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/PathUtil.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+/*
+ * path util
+ *
+ * @author lidongbo
+ */
+public class PathUtil {
+    
+    /**
+     * get real path.
+     *
+     * @param root root
+     * @param path path
+     * @return real path
+     */
+    public static String getRealPath(final String root, final String path) {
+        return adjustPath(root, path);
+    }
+    
+    private static String adjustPath(final String root, final String path) {
+        if (StringUtil.isNullOrBlank(path)) {
+            throw new IllegalArgumentException("path should have content!");
+        }
+        String rootPath = root;
+        if (!root.startsWith(Constants.PATH_SEPARATOR)) {
+            rootPath = Constants.PATH_SEPARATOR + root;
+        }
+        String subPath = path;
+        if (!path.startsWith(Constants.PATH_SEPARATOR)) {
+            subPath = Constants.PATH_SEPARATOR + path;
+        }
+        if (!subPath.startsWith(rootPath)) {
+            return rootPath + subPath;
+        }
+        return path;
+    }
+    
+    /**
+     * get path nodes, child to root.
+     *
+     * @param root root
+     * @param path path
+     * @return all path nodes
+     */
+    public static Stack<String> getPathReverseNodes(final String root, final String path) {
+        String realPath = adjustPath(root, path);
+        Stack<String> pathStack = new Stack<>();
+        int index = 1;
+        int position = realPath.indexOf(Constants.PATH_SEPARATOR, index);
+        do {
+            pathStack.push(realPath.substring(0, position));
+            index = position + 1;
+            position = realPath.indexOf(Constants.PATH_SEPARATOR, index);
+        }
+        while (position > -1);
+        pathStack.push(realPath);
+        return pathStack;
+    }
+    
+    /**
+     * get path nodes.
+     *
+     * @param root root
+     * @param path path
+     * @return all path nodes
+     */
+    public static List<String> getPathOrderNodes(final String root, final String path) {
+        String realPath = adjustPath(root, path);
+        List<String> paths = new ArrayList<>();
+        int index = 1;
+        int position = realPath.indexOf(Constants.PATH_SEPARATOR, index);
+    
+        do {
+            paths.add(realPath.substring(0, position));
+            index = position + 1;
+            position = realPath.indexOf(Constants.PATH_SEPARATOR, index);
+        }
+        while (position > -1);
+        paths.add(realPath);
+        return paths;
+    }
+    
+    /**
+     * get path nodes.
+     *
+     * @param path path
+     * @return all path nodes
+     */
+    public static List<String> getShortPathNodes(final String path) {
+        String realPath = checkPath(path);
+        List<String> paths = new ArrayList<>();
+        char[] chars = realPath.toCharArray();
+        StringBuilder builder = new StringBuilder(Constants.PATH_SEPARATOR);
+        for (int i = 1; i < chars.length; i++) {
+            if (chars[i] == Constants.PATH_SEPARATOR.charAt(0)) {
+                paths.add(builder.toString());
+                builder = new StringBuilder(Constants.PATH_SEPARATOR);
+                continue;
+            }
+            builder.append(chars[i]);
+            if (i == chars.length - 1) {
+                paths.add(builder.toString());
+            }
+        }
+        return paths;
+    }
+    
+    /**
+     * ignore invalid char and // /./  /../.
+     * code consult zookeeper
+     *
+     * @param key key
+     * @return real path
+     * @throws IllegalArgumentException IllegalArgumentException
+     */
+    // CHECKSTYLE:OFF
+    public static String checkPath(final String key) throws IllegalArgumentException {
+        // CHECKSTYLE:ON
+        if (StringUtil.isNullOrBlank(key)) {
+            throw new IllegalArgumentException("path should not be null");
+        }
+        String path = key;
+        if (path.charAt(0) != 47 || path.charAt(path.length() - 1) == 47) {
+            path = Constants.PATH_SEPARATOR + path;
+        }
+    
+        if (path.charAt(path.length() - 1) == 47) {
+            path = Constants.PATH_SEPARATOR + path;
+        }
+
+        char previous = 47;
+        char[] chars = path.toCharArray();
+        StringBuilder builder = new StringBuilder();
+        builder.append(previous);
+        
+        for (int i = 1; i < chars.length; ++i) {
+            char c = chars[i];
+            if (c == 0 || (c == 47 && previous == 47)) {
+                continue;
+            }
+            if (c == 46) {
+                // ignore /./  /../
+                boolean preWarn = previous == 47 || (previous == 46 && chars[i - 2] == 47);
+                if (previous == 47 && (i + 1 == chars.length || chars[i + 1] == 47)) {
+                    // CHECKSTYLE:OFF
+                    i++;
+                    continue;
+                }
+                if ((previous == 46 && chars[i - 2] == 47) && (i + 1 == chars.length || chars[i + 1] == 47)) {
+                    i += 2;
+                    continue;
+                }
+            }
+            
+            if (c > 0 && c < 31 || c > 127 && c < 159 || c > '\ud800' && c < '\uf8ff' || c > '\ufff0' && c < '\uffff') {
+                // CHECKSTYLE:ON
+                continue;
+            }
+    
+            builder.append(c);
+            previous = c;
+        }
+        return builder.toString();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/StringUtil.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/utility/StringUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility;
+
+/*
+ * @author lidongbo
+ */
+public class StringUtil {
+    
+    /**
+     * Null Or Blank.
+     *
+     * @param string string
+     * @return isNullOrBlank
+     */
+    public static boolean isNullOrBlank(final String string) {
+        return string == null || string.trim().length() == 0;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/CacheClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/CacheClient.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache.CacheStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.cache.PathTree;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseContext;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * todo
+ * @author lidongbo
+ */
+public final class CacheClient extends UsualClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CacheClient.class);
+    
+    private PathTree pathTree;
+    
+    CacheClient(final BaseContext context) {
+        super(context);
+    }
+    
+    @Override
+    public void start() throws IOException, InterruptedException {
+        super.start();
+        try {
+            useCacheStrategy(CacheStrategy.WATCH);
+        } catch (KeeperException e) {
+            LOGGER.error("CacheClient useCacheStrategy : " + e.getMessage());
+        }
+    }
+    
+    @Override
+    public void close() {
+        super.close();
+        this.pathTree.close();
+    }
+    
+    //todo put it here?
+    void useCacheStrategy(final CacheStrategy cacheStrategy) throws KeeperException, InterruptedException {
+        LOGGER.debug("use cache strategy:{}", cacheStrategy);
+        switch (cacheStrategy) {
+            case WATCH:
+                pathTree = new PathTree(getRootNode(), this);
+                pathTree.watch();
+                break;
+            case ALL:
+                pathTree = loadPathTree();
+                pathTree.refreshPeriodic(Constants.THREAD_PERIOD);
+                break;
+            case NONE:
+            default:
+                break;
+        }
+    }
+    
+    private PathTree loadPathTree() throws KeeperException, InterruptedException {
+        return loadPathTree(getRootNode());
+    }
+    
+    private PathTree loadPathTree(final String treeRoot) throws KeeperException, InterruptedException {
+        PathTree tree = new PathTree(treeRoot, this);
+        LOGGER.debug("load path tree:{}", treeRoot);
+        tree.load();
+        tree.watch();
+        return tree;
+    }
+    
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        super.createCurrentOnly(key, value, createMode);
+        pathTree.put(PathUtil.getRealPath(getRootNode(), key), value);
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        super.deleteOnlyCurrent(key);
+        pathTree.delete(PathUtil.getRealPath(getRootNode(), key));
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key, final AsyncCallback.VoidCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        super.deleteOnlyCurrent(key, callback, ctx);
+        pathTree.delete(PathUtil.getRealPath(getRootNode(), key));
+    }
+    
+    @Override
+    public byte[] getData(final String key) throws KeeperException, InterruptedException {
+        String path = PathUtil.getRealPath(getRootNode(), key);
+        byte[] data = pathTree.getValue(path);
+        if (data != null) {
+            LOGGER.debug("getData cache hit:{}", data);
+            return data;
+        }
+        LOGGER.debug("getData cache not hit:{}", data);
+        return getStrategy().getData(key);
+    }
+    
+    @Override
+    public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
+        String path = PathUtil.getRealPath(getRootNode(), key);
+        List<String> keys = pathTree.getChildren(path);
+        if (!keys.isEmpty()) {
+            LOGGER.debug("getChildren cache hit:{}", keys);
+            return keys;
+        }
+        LOGGER.debug("getChildren cache not hit:{}", keys);
+        return getStrategy().getChildren(PathUtil.getRealPath(getRootNode(), key));
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/ClientFactory.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/ClientFactory.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClientFactory;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.ClientContext;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * @author lidongbo
+ */
+public class ClientFactory extends BaseClientFactory {
+    //    private static final String CLIENT_EXCLUSIVE_NODE = "ZKC";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientFactory.class);
+    
+    private DelayRetryPolicy delayRetryPolicy;
+    
+    /**
+     * create a new client.
+     *
+     * @param servers servers
+     * @param sessionTimeoutMilliseconds sessionTimeoutMilliseconds
+     * @return ClientFactory this
+     */
+    public ClientFactory newClient(final String servers, final int sessionTimeoutMilliseconds) {
+        int wait = sessionTimeoutMilliseconds;
+        if (sessionTimeoutMilliseconds == 0) {
+            wait = Constants.WAIT;
+        }
+        setContext(new ClientContext(servers, wait));
+        setClient(new UsualClient(getContext()));
+        LOGGER.debug("new usual client");
+        return this;
+    }
+    
+    /*
+    * used for create new clients through a existing client
+    * this client is not perhaps the client
+    */
+    synchronized BaseClientFactory newClientByOriginal(final boolean closeOriginal) {
+        IClient oldClient = getClient();
+        setClient(new UsualClient(getContext()));
+        if (closeOriginal) {
+            oldClient.close();
+        }
+        LOGGER.debug("new usual client by a existing client");
+        return this;
+    }
+    
+    ClientFactory newCacheClient(final String servers, final int sessionTimeoutMilliseconds) {
+        setContext(new ClientContext(servers, sessionTimeoutMilliseconds));
+        setClient(new CacheClient(getContext()));
+        LOGGER.debug("new cache client");
+        return this;
+    }
+    
+    /**
+     * wait to register global listener.
+     *
+     * @param globalListener globalListener
+     * @return ClientFactory this
+     */
+    public ClientFactory watch(final Listener globalListener) {
+        setGlobalListener(globalListener);
+        return this;
+    }
+    
+    /**
+     * set client namespace.
+     *
+     * @param namespace namespace
+     * @return ClientFactory this
+     */
+    public ClientFactory setClientNamespace(final String namespace) {
+        setNamespace(PathUtil.checkPath(namespace));
+        return this;
+    }
+    
+    /**
+     * authorization.
+     *
+     * @param scheme scheme
+     * @param auth auth
+     * @param authorities authorities
+     * @return ClientFactory this
+     */
+    public ClientFactory authorization(final String scheme, final byte[] auth, final List<ACL> authorities) {
+        setScheme(scheme);
+        setAuth(auth);
+        setAuthorities(authorities);
+        return this;
+    }
+    
+    /**
+     * set delay retry policy.
+     *
+     * @param delayRetryPolicy delayRetryPolicy
+     * @return ClientFactory this
+     */
+    public ClientFactory setRetryPolicy(final DelayRetryPolicy delayRetryPolicy) {
+        this.delayRetryPolicy = delayRetryPolicy;
+        return this;
+    }
+    
+    @Override
+    public IClient start() throws IOException, InterruptedException {
+        ((ClientContext) getContext()).setDelayRetryPolicy(delayRetryPolicy);
+        ((ClientContext) getContext()).setClientFactory(this);
+        return super.start();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IExecStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseContext;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.ClientContext;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.StrategyType;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.AsyncRetryStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.ContentionStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.SyncRetryStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.UsualStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction.ZKTransaction;
+import lombok.Getter;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * @author lidongbo
+ */
+public class UsualClient extends BaseClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UsualClient.class);
+    
+    private final Map<StrategyType, IExecStrategy> strategies = new ConcurrentHashMap<>();
+    
+    private final boolean watched = true;
+    
+    @Getter
+    private IExecStrategy strategy;
+    
+    UsualClient(final BaseContext context) {
+        super(context);
+    }
+
+    @Override
+    public void start() throws IOException, InterruptedException {
+        super.start();
+        useExecStrategy(StrategyType.USUAL);
+    }
+    
+    @Override
+    public void close() {
+        this.strategies.clear();
+        super.close();
+    }
+    
+    @Override
+    public synchronized void useExecStrategy(final StrategyType strategyType) {
+        LOGGER.debug("useExecStrategy:{}", strategyType);
+        if (strategies.containsKey(strategyType)) {
+            strategy = strategies.get(strategyType);
+            return;
+        }
+        
+        IProvider provider = new BaseProvider(getRootNode(), getHolder(), watched, getAuthorities());
+        switch (strategyType) {
+            case USUAL:
+                strategy = new UsualStrategy(provider);
+                break;
+            case CONTEND:
+                strategy = new ContentionStrategy(provider);
+                break;
+            case SYNC_RETRY:
+                strategy = new SyncRetryStrategy(provider, ((ClientContext) getContext()).getDelayRetryPolicy());
+                break;
+            case ASYNC_RETRY:
+                strategy = new AsyncRetryStrategy(provider, ((ClientContext) getContext()).getDelayRetryPolicy());
+                break;
+            default:
+                strategy = new UsualStrategy(provider);
+                break;
+        }
+        
+        strategies.put(strategyType, strategy);
+    }
+    
+    @Override
+    public String getDataString(final String key) throws KeeperException, InterruptedException {
+        return strategy.getDataString(key);
+    }
+    
+    @Override
+    public byte[] getData(final String key) throws KeeperException, InterruptedException {
+        return strategy.getData(key);
+    }
+    
+    @Override
+    public void getData(final String key, final AsyncCallback.DataCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        strategy.getData(key, callback, ctx);
+    }
+    
+    @Override
+    public boolean checkExists(final String key) throws KeeperException, InterruptedException {
+        return strategy.checkExists(key);
+    }
+    
+    @Override
+    public boolean checkExists(final String key, final Watcher watcher) throws KeeperException, InterruptedException {
+        return strategy.checkExists(key, watcher);
+    }
+    
+    @Override
+    public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
+        return strategy.getChildren(key);
+    }
+    
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        this.createNamespace();
+        if (getRootNode().equals(key)) {
+            return;
+        }
+        strategy.createCurrentOnly(key, value, createMode);
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        this.createNamespace();
+        if (getRootNode().equals(key)) {
+            return;
+        }
+        strategy.createAllNeedPath(key, value, createMode);
+    }
+    
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        strategy.update(key, value);
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        if (getRootNode().equals(key)) {
+            deleteNamespace();
+            return;
+        }
+        strategy.deleteOnlyCurrent(key);
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key, final AsyncCallback.VoidCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        if (getRootNode().equals(key)) {
+            deleteNamespace();
+            return;
+        }
+        strategy.deleteOnlyCurrent(key, callback, ctx);
+    }
+    
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        strategy.deleteAllChildren(key);
+        if (getRootNode().equals(key)) {
+            setRootExist(false);
+            LOGGER.debug("deleteAllChildren delete root:{}", getRootNode());
+        }
+    }
+    
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        strategy.deleteCurrentBranch(key);
+        if (!strategy.checkExists(getRootNode())) {
+            setRootExist(false);
+            LOGGER.debug("deleteCurrentBranch delete root:{}", getRootNode());
+        }
+    }
+    
+    @Override
+    public ZKTransaction transaction() {
+        return new ZKTransaction(getRootNode(), getHolder());
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.StringUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.WatcherCreator;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * @author lidongbo
+ */
+public abstract class BaseClient implements IClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
+    
+    private final int circleWait = 30;
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private List<ACL> authorities;
+    
+    // false
+    @Setter(value = AccessLevel.PROTECTED)
+    private boolean rootExist;
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private Holder holder;
+    
+    @Setter(value = AccessLevel.PROTECTED)
+    @Getter(value = AccessLevel.PROTECTED)
+    private String rootNode = "/InitValue";
+    
+    @Getter
+    private BaseContext context;
+    
+    protected BaseClient(final BaseContext context) {
+        this.context = context;
+    }
+    
+    @Override
+    public void start() throws IOException, InterruptedException {
+        holder = new Holder(getContext());
+        holder.start();
+    }
+    
+    @Override
+    public synchronized boolean blockUntilConnected(final int wait, final TimeUnit units) throws InterruptedException {
+        long maxWait = units != null ? TimeUnit.MILLISECONDS.convert(wait, units) : 0;
+
+        while (!holder.isConnected()) {
+            long waitTime = maxWait - circleWait;
+            if (waitTime <= 0) {
+                return holder.isConnected();
+            }
+            wait(circleWait);
+        }
+        return true;
+    }
+    
+    @Override
+    public void close() {
+        context.close();
+        try {
+            this.deleteNamespace();
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            // CHECKSTYLE:ON
+            LOGGER.error("zk client close delete root error:{}", e.getMessage(), e);
+        }
+        holder.close();
+    }
+    
+    void registerWatch(final Listener globalListener) {
+        if (context.getGlobalListener() != null) {
+            LOGGER.warn("global listener can only register one");
+            return;
+        }
+        context.setGlobalListener(globalListener);
+        LOGGER.debug("globalListenerRegistered:{}", globalListener.getKey());
+    }
+    
+    @Override
+    public void registerWatch(final String key, final Listener listener) {
+        String path = PathUtil.getRealPath(rootNode, key);
+        listener.setPath(path);
+        context.getWatchers().put(listener.getKey(), listener);
+        LOGGER.debug("register watcher:{}", path);
+    }
+    
+    @Override
+    public void unregisterWatch(final String key) {
+        if (StringUtil.isNullOrBlank(key)) {
+            throw new IllegalArgumentException("key should not be blank");
+        }
+//        String path = PathUtil.getRealPath(rootNode, key);
+        if (context.getWatchers().containsKey(key)) {
+            context.getWatchers().remove(key);
+            LOGGER.debug("unregisterWatch:{}", key);
+        }
+    }
+    
+    protected void createNamespace() throws KeeperException, InterruptedException {
+        createNamespace(Constants.NOTHING_DATA);
+    }
+    
+    protected void createNamespace(final byte[] date) throws KeeperException, InterruptedException {
+        if (rootExist) {
+            LOGGER.debug("root exist");
+            return;
+        }
+        try {
+            if (null == holder.getZooKeeper().exists(rootNode, false)) {
+                holder.getZooKeeper().create(rootNode, date, authorities, CreateMode.PERSISTENT);
+            }
+            rootExist = true;
+            LOGGER.debug("creating root:{}", rootNode);
+        } catch (KeeperException.NodeExistsException e) {
+            LOGGER.warn("root create:{}", e.getMessage());
+            rootExist = true;
+            return;
+        }
+        holder.getZooKeeper().exists(rootNode, WatcherCreator.deleteWatcher(new Listener(rootNode) {
+            @Override
+            public void process(final WatchedEvent event) {
+                rootExist = false;
+            }
+        }));
+        LOGGER.debug("created root:{}", rootNode);
+    }
+    
+    protected void deleteNamespace() throws KeeperException, InterruptedException {
+        try {
+            holder.getZooKeeper().delete(rootNode, Constants.VERSION);
+        } catch (KeeperException.NodeExistsException | KeeperException.NotEmptyException e) {
+            LOGGER.info("delete root :{}", e.getMessage());
+        }
+        rootExist = false;
+        LOGGER.debug("delete root:{},rootExist:{}", rootNode, rootExist);
+    }
+    
+    void setAuthorities(final String scheme, final byte[] auth, final List<ACL> authorities) {
+        context.setScheme(scheme);
+        context.setAuth(auth);
+        this.authorities = authorities;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientFactory.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * @author lidongbo
+ */
+@Setter(value = AccessLevel.PROTECTED)
+@Getter(value = AccessLevel.PROTECTED)
+public abstract class BaseClientFactory {
+    private BaseClient client;
+    
+    private Listener globalListener;
+    
+    private String namespace;
+    
+    private String scheme;
+    
+    private byte[] auth;
+    
+    private List<ACL> authorities;
+    
+    private BaseContext context;
+    
+    /**
+     * start.
+     *
+     * @return client
+     * @throws IOException IO Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public IClient start() throws IOException, InterruptedException {
+        client.setRootNode(namespace);
+        if (scheme == null) {
+            authorities = ZooDefs.Ids.OPEN_ACL_UNSAFE;
+        }
+        client.setAuthorities(scheme, auth, authorities);
+        client.start();
+        if (globalListener != null) {
+            client.registerWatch(globalListener);
+        }
+        return client;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseContext.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * @author lidongbo
+ */
+@Getter
+@Setter(value = AccessLevel.PROTECTED)
+public abstract class BaseContext {
+    private String servers;
+    
+    private int sessionTimeOut;
+    
+    private String scheme;
+    
+    private byte[] auth;
+    
+    private Listener globalListener;
+    
+    private final Map<String, Listener> watchers = new ConcurrentHashMap<>();
+    
+    /**
+     * close.
+     */
+    public void close() {
+        this.watchers.clear();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseOperation.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayPolicyExecutor;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Connection;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * base async retry operation
+ *
+ * @author lidongbo
+ */
+@Getter(value = AccessLevel.PROTECTED)
+public abstract class BaseOperation implements Delayed {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseOperation.class);
+    
+    private final IProvider provider;
+    
+    @Setter
+    private DelayPolicyExecutor delayPolicyExecutor;
+    
+    protected BaseOperation(final IProvider provider) {
+        this.provider = provider;
+    }
+    
+    @Override
+    public long getDelay(final TimeUnit unit) {
+        long absoluteBlock = this.delayPolicyExecutor.getNextTick() - System.currentTimeMillis();
+        LOGGER.debug("queue getDelay block:{}", absoluteBlock);
+        return unit.convert(absoluteBlock, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * queue precedence.
+     */
+    @Override
+    public int compareTo(final Delayed delayed) {
+        return (int) (this.getDelay(TimeUnit.MILLISECONDS) - delayed.getDelay(TimeUnit.MILLISECONDS));
+    }
+
+    protected abstract void execute() throws KeeperException, InterruptedException;
+    
+    /**
+     * queue precedence.
+     *
+     * @return whether or not continue enqueue
+     * @throws KeeperException Keeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public boolean executeOperation() throws KeeperException, InterruptedException {
+        boolean result;
+        try {
+            execute();
+            result = true;
+        } catch (KeeperException e) {
+            if (Connection.needReset(e)) {
+                provider.resetConnection();
+                result = false;
+            } else {
+                throw e;
+            }
+        }
+        if (!result && delayPolicyExecutor.hasNext()) {
+            delayPolicyExecutor.next();
+            return true;
+        }
+        return false;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseProvider.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseProvider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.election.LeaderElection;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction.ZKTransaction;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Stack;
+
+/*
+ * @author lidongbo
+ */
+public class BaseProvider implements IProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseProvider.class);
+    
+    @Getter
+    private final Holder holder;
+    
+    @Getter
+    private final String rootNode;
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private final boolean watched;
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private final List<ACL> authorities;
+    
+    public BaseProvider(final String rootNode, final Holder holder, final boolean watched, final List<ACL> authorities) {
+        this.rootNode = rootNode;
+        this.holder = holder;
+        this.watched = watched;
+        this.authorities = authorities;
+    }
+    
+    @Override
+    public String getDataString(final String key) throws KeeperException, InterruptedException {
+        return new String(getData(key));
+    }
+    
+    @Override
+    public byte[] getData(final String key) throws KeeperException, InterruptedException {
+        return holder.getZooKeeper().getData(key, watched, null);
+    }
+    
+    @Override
+    public void getData(final String key, final AsyncCallback.DataCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        holder.getZooKeeper().getData(key, watched, callback, ctx);
+    }
+    
+    @Override
+    public boolean exists(final String key) throws KeeperException, InterruptedException {
+        return null != holder.getZooKeeper().exists(key, watched);
+    }
+    
+    @Override
+    public boolean exists(final String key, final Watcher watcher) throws KeeperException, InterruptedException {
+        return null != holder.getZooKeeper().exists(key, watcher);
+    }
+    
+    @Override
+    public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
+        return holder.getZooKeeper().getChildren(key, watched);
+    }
+    
+    @Override
+    public void create(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        holder.getZooKeeper().create(key, value.getBytes(Constants.UTF_8), authorities, createMode);
+        LOGGER.debug("BaseProvider createCurrentOnly:{}", key);
+//        create(key, value, createMode, new AtomicInteger());
+    }
+
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        holder.getZooKeeper().setData(key, value.getBytes(Constants.UTF_8), Constants.VERSION);
+    }
+    
+    @Override
+    public void delete(final String key) throws KeeperException, InterruptedException {
+        holder.getZooKeeper().delete(key, Constants.VERSION);
+        LOGGER.debug("BaseProvider deleteOnlyCurrent:{}", key);
+    }
+    
+    @Override
+    public void delete(final String key, final AsyncCallback.VoidCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        holder.getZooKeeper().delete(key, Constants.VERSION, callback, ctx);
+        LOGGER.debug("BaseProvider deleteOnlyCurrent:{},ctx:{}", key, ctx);
+    }
+
+    @Override
+    public String getRealPath(final String path) {
+        return PathUtil.getRealPath(rootNode, path);
+    }
+    
+    @Override
+    public List<String> getNecessaryPaths(final String key) {
+        List<String> nodes = PathUtil.getPathOrderNodes(rootNode, key);
+        nodes.remove(rootNode);
+        return nodes;
+    }
+    
+    @Override
+    public Stack<String> getDeletingPaths(final String key) {
+        return PathUtil.getPathReverseNodes(rootNode, key);
+    }
+    
+    @Override
+    public void executeContention(final LeaderElection election) throws KeeperException, InterruptedException {
+        this.executeContention(rootNode, election);
+    }
+    
+    private void executeContention(final String nodeBeCompete, final LeaderElection election) throws KeeperException, InterruptedException {
+        election.executeContention(nodeBeCompete, this);
+    }
+    
+    @Override
+    public void createInTransaction(final String key, final String value, final CreateMode createMode, final ZKTransaction transaction) throws KeeperException, InterruptedException {
+        transaction.create(key, value.getBytes(Constants.UTF_8), authorities, createMode);
+    }
+    
+    @Override
+    public void resetConnection() {
+        try {
+            holder.reset();
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            // CHECKSTYLE:ON
+            LOGGER.error("resetConnection Exception:{}", e.getMessage(), e);
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IExecStrategy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import lombok.Getter;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * @author lidongbo
+ */
+public abstract class BaseStrategy implements IExecStrategy {
+    
+    @Getter
+    private final IProvider provider;
+    
+    public BaseStrategy(final IProvider provider) {
+        this.provider = provider;
+    }
+    
+    @Override
+    public String getDataString(final String key) throws KeeperException, InterruptedException {
+        return new String(getData(key));
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.StringUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+/*
+ * zookeeper connection holder
+ *
+ * @author lidongbo
+ */
+public class Holder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Holder.class);
+    
+    private static final CountDownLatch CONNECTED = new CountDownLatch(1);
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private final BaseContext context;
+    
+    @Getter
+    private ZooKeeper zooKeeper;
+    
+    @Getter
+    private boolean connected;
+    
+    Holder(final BaseContext context) {
+        this.context = context;
+    }
+    
+    /**
+     * start.
+     *
+     * @throws IOException IO Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public void start() throws IOException, InterruptedException {
+        LOGGER.debug("Holder servers:{},sessionTimeOut:{}", context.getServers(), context.getSessionTimeOut());
+        zooKeeper = new ZooKeeper(context.getServers(), context.getSessionTimeOut(), startWatcher());
+        if (!StringUtil.isNullOrBlank(context.getScheme())) {
+            zooKeeper.addAuthInfo(context.getScheme(), context.getAuth());
+            LOGGER.debug("Holder scheme:{},auth:{}", context.getScheme(), context.getAuth());
+        }
+        CONNECTED.await();
+    }
+    
+    private Watcher startWatcher() {
+        return new Watcher() {
+            public void process(final WatchedEvent event) {
+                processConnection(event);
+                if (context.getGlobalListener() != null) {
+                    context.getGlobalListener().process(event);
+                    LOGGER.debug("BaseClient {} process", Constants.GLOBAL_LISTENER_KEY);
+                }
+                if (!context.getWatchers().isEmpty()) {
+                    for (Listener listener : context.getWatchers().values()) {
+                        if (listener.getPath() == null || listener.getPath().equals(event.getPath())) {
+                            LOGGER.debug("listener process:{}, listener:{}", listener.getPath(), listener.getKey());
+                            listener.process(event);
+                        }
+                    }
+                }
+            }
+        };
+    }
+    
+    private void processConnection(final WatchedEvent event) {
+        LOGGER.debug("BaseClient process event:{}", event.toString());
+        if (Watcher.Event.EventType.None == event.getType()) {
+            if (Watcher.Event.KeeperState.SyncConnected == event.getState()) {
+                CONNECTED.countDown();
+                connected = true;
+                LOGGER.debug("BaseClient startWatcher SyncConnected");
+                return;
+            } else if (Watcher.Event.KeeperState.Expired == event.getState()) {
+                connected = false;
+                try {
+                    LOGGER.warn("startWatcher Event.KeeperState.Expired");
+                    reset();
+                    // CHECKSTYLE:OFF
+                } catch (Exception e) {
+                    // CHECKSTYLE:ON
+                    LOGGER.error("event state Expired:{}", e.getMessage(), e);
+                }
+            }
+        }
+    }
+    
+    /**
+     * reset connection.
+     *
+     * @throws IOException IO Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public void reset() throws IOException, InterruptedException {
+        LOGGER.debug("zk reset....................................");
+        close();
+        start();
+        LOGGER.debug("....................................zk reset");
+    }
+    
+    /**
+     * close.
+     */
+    public void close() {
+        try {
+            zooKeeper.close();
+            connected = false;
+            LOGGER.debug("zk closed");
+            this.context.close();
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            // CHECKSTYLE:ON
+            LOGGER.warn("Holder close:{}", e.getMessage());
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/CreateAllNeedOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/CreateAllNeedOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.UsualStrategy;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class CreateAllNeedOperation extends BaseOperation {
+    private final String key;
+    
+    private final String value;
+    
+    private final CreateMode createMode;
+    
+    public CreateAllNeedOperation(final IProvider provider, final String key, final String value, final CreateMode createMode) {
+        super(provider);
+        this.key = key;
+        this.value = value;
+        this.createMode = createMode;
+    }
+    
+    @Override
+    protected void execute() throws KeeperException, InterruptedException {
+        new UsualStrategy(getProvider()).createAllNeedPath(key, value, createMode);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("CreateAllNeedOperation key:%s,value:%s,createMode:%s", key, value, createMode.name());
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/CreateCurrentOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/CreateCurrentOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class CreateCurrentOperation extends BaseOperation {
+    private final String key;
+    
+    private final String value;
+    
+    private final CreateMode createMode;
+    
+    public CreateCurrentOperation(final IProvider provider, final String key, final String value, final CreateMode createMode) {
+        super(provider);
+        this.key = key;
+        this.value = value;
+        this.createMode = createMode;
+    }
+    
+    @Override
+    public void execute() throws KeeperException, InterruptedException {
+        getProvider().create(getProvider().getRealPath(key), value, createMode);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("CreateCurrentOperation key:%s,value:%s,createMode:%s", key, value, createMode.name());
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteAllChildrenOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteAllChildrenOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.UsualStrategy;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class DeleteAllChildrenOperation extends BaseOperation {
+    private final String key;
+    
+    public DeleteAllChildrenOperation(final IProvider provider, final String key) {
+        super(provider);
+        this.key = key;
+    }
+    
+    @Override
+    protected void execute() throws KeeperException, InterruptedException {
+        new UsualStrategy(getProvider()).deleteAllChildren(key);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("DeleteAllChildrenOperation key:%s", key);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteCurrentBranchOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteCurrentBranchOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.UsualStrategy;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class DeleteCurrentBranchOperation extends BaseOperation {
+    private final String key;
+    
+    public DeleteCurrentBranchOperation(final IProvider provider, final String key) {
+        super(provider);
+        this.key = key;
+    }
+    
+    @Override
+    protected void execute() throws KeeperException, InterruptedException {
+        new UsualStrategy(getProvider()).deleteCurrentBranch(key);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("DeleteCurrentBranchOperation key:%s", key);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteCurrentOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/DeleteCurrentOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class DeleteCurrentOperation extends BaseOperation {
+    private final String key;
+    
+    public DeleteCurrentOperation(final IProvider provider, final String key) {
+        super(provider);
+        this.key = key;
+    }
+    
+    @Override
+    protected void execute() throws KeeperException, InterruptedException {
+        getProvider().delete(getProvider().getRealPath(key));
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("DeleteCurrentOperation key:%s", key);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/UpdateOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/operation/UpdateOperation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseOperation;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * async retry
+ *
+ * @author lidongbo
+ */
+public class UpdateOperation extends BaseOperation {
+    private final String key;
+    
+    private final String value;
+    
+    public UpdateOperation(final IProvider provider, final String key, final String value) {
+        super(provider);
+        this.key = key;
+        this.value = value;
+    }
+    
+    @Override
+    protected void execute() throws KeeperException, InterruptedException {
+        getProvider().update(getProvider().getRealPath(key), value);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("UpdateOperation key:%s,value:%s", key, value);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Callable.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Callable.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayPolicyExecutor;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import lombok.Setter;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * sync retry call
+ *
+ * @author lidongbo
+ */
+public abstract class Callable<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Callable.class);
+
+    private final DelayPolicyExecutor delayPolicyExecutor;
+    
+    private final IProvider provider;
+    
+    @Setter
+    private T result;
+    
+    public Callable(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        this.delayPolicyExecutor = new DelayPolicyExecutor(delayRetryPolicy);
+        this.provider = provider;
+    }
+    
+    /**
+     * call.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public abstract void call() throws KeeperException, InterruptedException;
+    
+    /**
+     * get result.
+     *
+     * @return result
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public T getResult() throws KeeperException, InterruptedException {
+        if (result == null) {
+            exec();
+        }
+        return result;
+    }
+    
+    /**
+     * call without result.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public void exec() throws KeeperException, InterruptedException {
+        try {
+            call();
+        } catch (KeeperException e) {
+            LOGGER.warn("exec KeeperException:{}", e.getMessage());
+            delayPolicyExecutor.next();
+            if (Connection.needReset(e)) {
+                provider.resetConnection();
+            } else {
+                throw e;
+            }
+            execDelay();
+        } catch (InterruptedException e) {
+            throw e;
+        }
+    }
+    
+    private void execDelay() throws KeeperException, InterruptedException {
+        for (;;) {
+            long delay = delayPolicyExecutor.getNextTick() - System.currentTimeMillis();
+            if (delay > 0) {
+                try {
+                    LOGGER.debug("exec delay:{}", delay);
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    throw e;
+                }
+            } else {
+                if (delayPolicyExecutor.hasNext()) {
+                    LOGGER.debug("exec hasNext");
+                    exec();
+                }
+                break;
+            }
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/ClientContext.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/ClientContext.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClientFactory;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseContext;
+import lombok.Getter;
+import lombok.Setter;
+
+/*
+ * @author lidongbo
+ */
+@Setter
+@Getter
+public final class ClientContext extends BaseContext {
+    
+    private DelayRetryPolicy delayRetryPolicy;
+    
+    private BaseClientFactory clientFactory;
+    
+    public ClientContext(final String servers, final int sessionTimeoutMilliseconds) {
+        super();
+        setServers(servers);
+        setSessionTimeOut(sessionTimeoutMilliseconds);
+    }
+    
+    /**
+     * call.
+     */
+    public void close() {
+        super.close();
+        this.delayRetryPolicy = null;
+        this.clientFactory = null;
+    }
+    
+    /**
+     * update context.
+     *
+     * @param context context
+     */
+    public void updateContext(final ClientContext context) {
+        this.delayRetryPolicy = context.getDelayRetryPolicy();
+        this.clientFactory = context.clientFactory;
+        getWatchers().clear();
+        getWatchers().putAll(context.getWatchers());
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/ClientTask.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/ClientTask.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * @author lidongbo
+ */
+public abstract class ClientTask implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientTask.class);
+    
+    private final IProvider provider;
+    
+    public ClientTask(final IProvider provider) {
+        this.provider = provider;
+    }
+    
+    /**
+     * run.
+     *
+     * @param provider provider
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public abstract void run(IProvider provider) throws KeeperException, InterruptedException;
+    
+    @Override
+    public void run() {
+        try {
+            run(provider);
+        } catch (KeeperException | InterruptedException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import org.apache.zookeeper.KeeperException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+ * @author lidongbo
+ */
+public class Connection {
+    //is need reset
+    private static final Map<Integer, Boolean> EXCEPTION_RESETS = new ConcurrentHashMap<>();
+
+    static {
+        EXCEPTION_RESETS.put(KeeperException.Code.SESSIONEXPIRED.intValue(), true);
+        EXCEPTION_RESETS.put(KeeperException.Code.SESSIONMOVED.intValue(), true);
+        EXCEPTION_RESETS.put(KeeperException.Code.CONNECTIONLOSS.intValue(), false);
+        EXCEPTION_RESETS.put(KeeperException.Code.OPERATIONTIMEOUT.intValue(), false);
+    }
+    
+    /**
+     * need reset.
+     *
+     * @param e e
+     * @return need reset
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public static boolean needReset(final KeeperException e) throws KeeperException {
+        int code = e.code().intValue();
+        if (!EXCEPTION_RESETS.containsKey(code)) {
+            throw e;
+        }
+        return EXCEPTION_RESETS.get(code);
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Listener.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Listener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.zookeeper.WatchedEvent;
+
+/*
+ * @author lidongbo
+ */
+@Getter
+public abstract class Listener {
+    private final String key;
+    
+    @Setter
+    private String path;
+    
+    public Listener() {
+        this(null);
+    }
+    
+    public Listener(final String path) {
+        this.path = path;
+        this.key = path + System.currentTimeMillis();
+    }
+    
+    /**
+     * process.
+     *
+     * @param event event
+     */
+    public abstract void process(WatchedEvent event);
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/StrategyType.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/StrategyType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+/*
+ * @author lidongbo
+ */
+public enum StrategyType {
+    USUAL,
+    CONTEND,
+    SYNC_RETRY,
+    ASYNC_RETRY,
+    ALL_ASYNC_RETRY
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/WatcherCreator.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/WatcherCreator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * @author lidongbo
+ */
+public class WatcherCreator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WatcherCreator.class);
+    
+    /**
+     * get string type data.
+     *
+     * @param listener listener
+     * @return watcher
+     */
+    public static Watcher deleteWatcher(final Listener listener) {
+        return new Watcher() {
+            @Override
+            public void process(final WatchedEvent event) {
+                if (listener.getPath().equals(event.getPath()) && Event.EventType.NodeDeleted.equals(event.getType())) {
+                    listener.process(event);
+                    LOGGER.debug("delete node event:{}", event.toString());
+                }
+            }
+        };
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.AsyncRetryCenter;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.CreateAllNeedOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.CreateCurrentOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.DeleteAllChildrenOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.DeleteCurrentBranchOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.DeleteCurrentOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.UpdateOperation;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * async retry strategy
+ *
+ * @author lidongbo
+ */
+public class AsyncRetryStrategy extends SyncRetryStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AsyncRetryStrategy.class);
+    
+    public AsyncRetryStrategy(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        super(provider, delayRetryPolicy);
+        AsyncRetryCenter.INSTANCE.init(getDelayRetryPolicy());
+        AsyncRetryCenter.INSTANCE.start();
+    }
+    
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        String path = getProvider().getRealPath(key);
+        try {
+            getProvider().create(path, value, createMode);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AsyncRetryStrategy SessionExpiredException createCurrentOnly:{}", path);
+            AsyncRetryCenter.INSTANCE.add(new CreateCurrentOperation(getProvider(), path, value, createMode));
+        }
+    }
+    
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        String path = getProvider().getRealPath(key);
+        try {
+            getProvider().update(path, value);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AsyncRetryStrategy SessionExpiredException update:{}", path);
+            AsyncRetryCenter.INSTANCE.add(new UpdateOperation(getProvider(), path, value));
+        }
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        String path = getProvider().getRealPath(key);
+        try {
+            getProvider().delete(path);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AsyncRetryStrategy SessionExpiredException deleteOnlyCurrent:{}", path);
+            AsyncRetryCenter.INSTANCE.add(new DeleteCurrentOperation(getProvider(), path));
+        }
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        try {
+            super.createAllNeedPath(key, value, createMode);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException CreateAllNeedOperation:{}", key);
+            AsyncRetryCenter.INSTANCE.add(new CreateAllNeedOperation(getProvider(), key, value, createMode));
+        }
+    }
+    
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        try {
+            super.deleteAllChildren(key);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteAllChildren:{}", key);
+            AsyncRetryCenter.INSTANCE.add(new DeleteAllChildrenOperation(getProvider(), key));
+        }
+    }
+    
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        try {
+            super.deleteCurrentBranch(key);
+        } catch (KeeperException.SessionExpiredException e) {
+            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteCurrentBranch:{}", key);
+            AsyncRetryCenter.INSTANCE.add(new DeleteCurrentBranchOperation(getProvider(), key));
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/ContentionStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/ContentionStrategy.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.Callback;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.election.LeaderElection;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Stack;
+
+/*
+ * The ContentionStrategy is effective only when all the clients of the node which be competitive are using ContentionStrategy.
+ *
+ * @author lidongbo
+ */
+public class ContentionStrategy extends UsualStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContentionStrategy.class);
+    
+    public ContentionStrategy(final IProvider provider) {
+        super(provider);
+    }
+    
+    @Override
+    /*
+    * Don't use this if you don't have to use it.
+    */
+    public void getData(final String key, final AsyncCallback.DataCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        LeaderElection election = new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                getProvider().getData(getProvider().getRealPath(key), callback, ctx);
+                LOGGER.debug("ContentionStrategy getData action:{}", key);
+            }
+        };
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy getData executeContention");
+    }
+
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        LeaderElection election = buildCreateElection(key, value, createMode, null);
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy createCurrentOnly executeContention");
+        election.waitDone();
+    }
+    
+    private LeaderElection buildCreateElection(final String key, final String value, final CreateMode createMode, final Callback callback) {
+        return new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                getProvider().create(getProvider().getRealPath(key), value, createMode);
+            }
+            
+            @Override
+            public void callback() {
+                if (callback != null) {
+                    callback.processResult();
+                }
+            }
+        };
+    }
+    
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        LeaderElection election = buildUpdateElection(key, value, null);
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy update executeContention");
+        election.waitDone();
+    }
+    
+    private LeaderElection buildUpdateElection(final String key, final String value, final Callback callback) {
+        return new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                getProvider().update(getProvider().getRealPath(key), value);
+                LOGGER.debug("ContentionStrategy update action:{},value:{}", key, value);
+            }
+            
+            @Override
+            public void callback() {
+                if (callback != null) {
+                    callback.processResult();
+                }
+            }
+        };
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        LeaderElection election = buildDeleteElection(key, null);
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy deleteOnlyCurrent executeContention");
+        election.waitDone();
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key, final AsyncCallback.VoidCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        getProvider().executeContention(new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                getProvider().delete(getProvider().getRealPath(key), callback, ctx);
+                LOGGER.debug("ContentionStrategy deleteOnlyCurrent action:{},ctx:{}", key, ctx);
+            }
+        });
+    }
+    
+    private LeaderElection buildDeleteElection(final String key, final Callback callback) {
+        return new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                getProvider().delete(getProvider().getRealPath(key));
+            }
+            
+            @Override
+            public void callback() {
+                if (callback != null) {
+                    callback.processResult();
+                }
+            }
+        };
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        LeaderElection election = buildCreateAllNeedElection(key, value, createMode, null);
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy createAllNeedPath executeContention");
+        election.waitDone();
+    }
+    
+    private LeaderElection buildCreateAllNeedElection(final String key, final String value, final CreateMode createMode, final Callback callback) {
+        return new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                LOGGER.debug("ContentionStrategy createAllNeedPath action:{}", key);
+                createBegin(getProvider().getRealPath(key), value, createMode);
+            }
+            
+            @Override
+            public void callback() {
+                if (callback != null) {
+                    callback.processResult();
+                }
+            }
+        };
+    }
+    
+    private void createBegin(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        if (key.indexOf(Constants.PATH_SEPARATOR) < -1) {
+            getProvider().create(key, value, createMode);
+            return;
+        }
+        List<String> nodes = getProvider().getNecessaryPaths(key);
+        for (int i = 0; i < nodes.size(); i++) {
+            if (getProvider().exists(nodes.get(i))) {
+                LOGGER.info("create node exist:{}", nodes.get(i));
+                continue;
+            }
+            LOGGER.debug("create node not exist:", nodes.get(i));
+            if (i == nodes.size() - 1) {
+                getProvider().create(nodes.get(i), value, createMode);
+            } else {
+                getProvider().create(nodes.get(i), Constants.NOTHING_VALUE, createMode);
+            }
+        }
+    }
+
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        getProvider().executeContention(new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                deleteChildren(getProvider().getRealPath(key), true);
+            }
+        });
+        LOGGER.debug("ContentionStrategy deleteAllChildren executeContention");
+    }
+    
+    private void deleteChildren(final String key, final boolean deleteCurrentNode) throws KeeperException, InterruptedException {
+        List<String> children = getProvider().getChildren(key);
+        LOGGER.debug("deleteChildren:{}", children);
+        for (int i = 0; i < children.size(); i++) {
+            String child = PathUtil.getRealPath(key, children.get(i));
+            if (!getProvider().exists(child)) {
+                LOGGER.info("delete not exist:{}", child);
+                continue;
+            }
+            LOGGER.debug("deleteChildren:{}", child);
+            deleteChildren(child, true);
+        }
+        if (deleteCurrentNode) {
+            getProvider().delete(key);
+        }
+    }
+    
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        getProvider().executeContention(new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                deleteBranch(getProvider().getRealPath(key));
+            }
+        });
+        LOGGER.debug("ContentionStrategy deleteCurrentBranch executeContention");
+    }
+    
+    private void deleteBranch(final String key) throws KeeperException, InterruptedException {
+        deleteChildren(key, false);
+        Stack<String> pathStack = getProvider().getDeletingPaths(key);
+        while (!pathStack.empty()) {
+            String node = pathStack.pop();
+            // contrast cache
+            if (getProvider().exists(node)) {
+                try {
+                    getProvider().delete(node);
+                } catch (KeeperException.NotEmptyException e) {
+                    LOGGER.warn("deleteBranch {} exist other children:{}", node, this.getChildren(node));
+                    LOGGER.debug(e.getMessage());
+                    return;
+                }
+            }
+            LOGGER.info("deleteBranch node not exist:{}", node);
+        }
+    }
+    
+    //todo Use arbitrary competitive nodes
+    //IExecStrategy convert to ContentionStrategy
+    /*public void createCurrentOnly(final String key, final String value, final CreateMode createMode, final Callback callback) throws KeeperException, InterruptedException {
+        getProvider().executeContention(buildCreateElection(key, value, createMode, callback));
+    }
+    
+    public void update(final String key, final String value, final Callback callback) throws KeeperException, InterruptedException {
+        getProvider().executeContention(buildUpdateElection(key, value, null));
+    }
+
+    public void deleteOnlyCurrent(final String key, final Callback callback) throws KeeperException, InterruptedException {
+        getProvider().executeContention(buildDeleteElection(key, null));
+    }*/
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Callable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/*
+ * sync retry strategy
+ *
+ * @author lidongbo
+ */
+public class SyncRetryStrategy extends UsualStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncRetryStrategy.class);
+    
+    @Getter(value = AccessLevel.PROTECTED)
+    private final DelayRetryPolicy delayRetryPolicy;
+    
+    public SyncRetryStrategy(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        super(provider);
+        if (delayRetryPolicy == null) {
+            LOGGER.warn("Callable constructor context's delayRetryPolicy is null");
+            this.delayRetryPolicy = DelayRetryPolicy.newNoInitDelayPolicy();
+        } else {
+            this.delayRetryPolicy = delayRetryPolicy;
+        }
+    }
+
+    @Override
+    public byte[] getData(final String key) throws KeeperException, InterruptedException {
+        Callable<byte[]> callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                setResult(getProvider().getData(getProvider().getRealPath(key)));
+            }
+        };
+        return callable.getResult();
+    }
+    
+    @Override
+    public boolean checkExists(final String key) throws KeeperException, InterruptedException {
+        Callable<Boolean> callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                setResult(getProvider().exists(getProvider().getRealPath(key)));
+            }
+        };
+        return callable.getResult();
+    }
+    
+    @Override
+    public boolean checkExists(final String key, final Watcher watcher) throws KeeperException, InterruptedException {
+        Callable<Boolean> callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                setResult(getProvider().exists(getProvider().getRealPath(key), watcher));
+            }
+        };
+        return callable.getResult();
+    }
+    
+    @Override
+    public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
+        Callable<List<String>> callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                setResult(getProvider().getChildren(getProvider().getRealPath(key)));
+            }
+        };
+        return callable.getResult();
+    }
+    
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                getProvider().create(getProvider().getRealPath(key), value, createMode);
+            }
+        };
+        callable.exec();
+    }
+    
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                getProvider().update(getProvider().getRealPath(key), value);
+            }
+        };
+        callable.exec();
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                getProvider().delete(getProvider().getRealPath(key));
+            }
+        };
+        callable.exec();
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                new UsualStrategy(getProvider()).createAllNeedPath(key, value, createMode);
+            }
+        };
+        callable.exec();
+    }
+    
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                new UsualStrategy(getProvider()).deleteAllChildren(key);
+            }
+        };
+        callable.exec();
+    }
+    
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        Callable callable = new Callable(getProvider(), delayRetryPolicy) {
+            @Override
+            public void call() throws KeeperException, InterruptedException {
+                new UsualStrategy(getProvider()).deleteCurrentBranch(key);
+            }
+        };
+        callable.exec();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/TransactionContendStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/TransactionContendStrategy.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.Callback;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.election.LeaderElection;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction.ZKTransaction;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Stack;
+
+/*
+ * @author lidongbo
+ * @since zookeeper 3.4.0
+ */
+public class TransactionContendStrategy extends ContentionStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionContendStrategy.class);
+    
+    public TransactionContendStrategy(final IProvider provider) {
+        super(provider);
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        LeaderElection election = buildCreateAllNeedElection(key, value, createMode, null);
+        getProvider().executeContention(election);
+        LOGGER.debug("ContentionStrategy createAllNeedPath executeContention");
+        election.waitDone();
+    }
+    
+    private LeaderElection buildCreateAllNeedElection(final String key, final String value, final CreateMode createMode, final Callback callback) {
+        return new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                LOGGER.debug("ContentionStrategy createAllNeedPath action:{}", key);
+                ZKTransaction transaction = new ZKTransaction(((BaseProvider) getProvider()).getRootNode(), ((BaseProvider) getProvider()).getHolder());
+                createBegin(key, value, createMode, transaction);
+                transaction.commit();
+            }
+            
+            @Override
+            public void callback() {
+                if (callback != null) {
+                    callback.processResult();
+                }
+            }
+        };
+    }
+
+    private void createBegin(final String key, final String value, final CreateMode createMode, final ZKTransaction transaction) throws KeeperException, InterruptedException {
+        if (key.indexOf(Constants.PATH_SEPARATOR) < -1) {
+            getProvider().createInTransaction(key, value, createMode, transaction);
+            return;
+        }
+        List<String> nodes = getProvider().getNecessaryPaths(key);
+        for (int i = 0; i < nodes.size(); i++) {
+            if (getProvider().exists(nodes.get(i))) {
+                LOGGER.info("create node exist:{}", nodes.get(i));
+                continue;
+            }
+            LOGGER.debug("node not exist and create:", nodes.get(i));
+            if (i == nodes.size() - 1) {
+                getProvider().createInTransaction(nodes.get(i), value, createMode, transaction);
+            } else {
+                getProvider().createInTransaction(nodes.get(i), Constants.NOTHING_VALUE, createMode, transaction);
+            }
+        }
+    }
+
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        getProvider().executeContention(new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                ZKTransaction transaction = new ZKTransaction(((BaseProvider) getProvider()).getRootNode(), ((BaseProvider) getProvider()).getHolder());
+                deleteChildren(getProvider().getRealPath(key), true, transaction);
+                transaction.commit();
+            }
+        });
+        LOGGER.debug("ContentionStrategy deleteAllChildren executeContention");
+    }
+    
+    private void deleteChildren(final String key, final boolean deleteCurrentNode, final ZKTransaction transaction) throws KeeperException, InterruptedException {
+        List<String> children = getProvider().getChildren(key);
+        for (int i = 0; i < children.size(); i++) {
+            String child = PathUtil.getRealPath(key, children.get(i));
+            if (!getProvider().exists(child)) {
+                LOGGER.info("delete not exist:{}", child);
+                continue;
+            }
+            LOGGER.debug("deleteChildren:{}", child);
+            deleteChildren(child, true, transaction);
+        }
+        if (deleteCurrentNode) {
+            transaction.delete(key, Constants.VERSION);
+        }
+    }
+    
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        getProvider().executeContention(new LeaderElection() {
+            @Override
+            public void action() throws KeeperException, InterruptedException {
+                ZKTransaction transaction = new ZKTransaction(((BaseProvider) getProvider()).getRootNode(), ((BaseProvider) getProvider()).getHolder());
+                deleteBranch(getProvider().getRealPath(key), transaction);
+                transaction.commit();
+            }
+        });
+        LOGGER.debug("ContentionStrategy deleteCurrentBranch executeContention");
+    }
+
+    private void deleteBranch(final String key, final ZKTransaction transaction) throws KeeperException, InterruptedException {
+        deleteChildren(key, false, transaction);
+        Stack<String> pathStack = getProvider().getDeletingPaths(key);
+        String prePath = key;
+        while (!pathStack.empty()) {
+            String node = pathStack.pop();
+            // contrast cache
+            // Performance needs testing
+            List<String> children = getProvider().getChildren(node);
+            boolean canDelete = children.size() == 0 || children.size() == 1;
+            if (children.size() == 1) {
+                if (!PathUtil.getRealPath(node, children.get(0)).equals(prePath)) {
+                    canDelete = false;
+                }
+            }
+            if (getProvider().exists(node) && canDelete) {
+                transaction.delete(node, Constants.VERSION);
+            }
+            prePath = node;
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/UsualStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/UsualStrategy.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseStrategy;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/*
+ * usual strategy
+ * 
+ * @author lidongbo
+ */
+public class UsualStrategy extends BaseStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UsualStrategy.class);
+    
+    public UsualStrategy(final IProvider provider) {
+        super(provider);
+    }
+    
+    @Override
+    public byte[] getData(final String key) throws KeeperException, InterruptedException {
+        return getProvider().getData(getProvider().getRealPath(key));
+    }
+    
+    @Override
+    public void getData(final String key, final AsyncCallback.DataCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        getProvider().getData(getProvider().getRealPath(key), callback, ctx);
+    }
+    
+    @Override
+    public boolean checkExists(final String key) throws KeeperException, InterruptedException {
+        return getProvider().exists(getProvider().getRealPath(key));
+    }
+    
+    @Override
+    public boolean checkExists(final String key, final Watcher watcher) throws KeeperException, InterruptedException {
+        return getProvider().exists(getProvider().getRealPath(key), watcher);
+    }
+    
+    @Override
+    public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
+        return getProvider().getChildren(getProvider().getRealPath(key));
+    }
+    
+    @Override
+    public void createCurrentOnly(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        getProvider().create(getProvider().getRealPath(key), value, createMode);
+    }
+    
+    @Override
+    public void update(final String key, final String value) throws KeeperException, InterruptedException {
+        getProvider().update(getProvider().getRealPath(key), value);
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key) throws KeeperException, InterruptedException {
+        getProvider().delete(getProvider().getRealPath(key));
+    }
+    
+    @Override
+    public void deleteOnlyCurrent(final String key, final AsyncCallback.VoidCallback callback, final Object ctx) throws KeeperException, InterruptedException {
+        getProvider().delete(getProvider().getRealPath(key), callback, ctx);
+    }
+    
+    @Override
+    public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
+        if (key.indexOf(Constants.PATH_SEPARATOR) < -1) {
+            this.createCurrentOnly(key, value, createMode);
+            return;
+        }
+        List<String> nodes = getProvider().getNecessaryPaths(key);
+        for (int i = 0; i < nodes.size(); i++) {
+            try {
+//                this.deleteAllChildren(nodes.get(i));
+                if (i == nodes.size() - 1) {
+                    this.createCurrentOnly(nodes.get(i), value, createMode);
+                } else {
+                    this.createCurrentOnly(nodes.get(i), Constants.NOTHING_VALUE, CreateMode.PERSISTENT);
+                }
+                LOGGER.debug("node not exist and create:", nodes.get(i));
+            } catch (KeeperException.NodeExistsException e) {
+                LOGGER.debug("create node exist:{}", nodes.get(i));
+            }
+        }
+    }
+    
+    @Override
+    public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
+        LOGGER.debug("deleteAllChildren:{}", key);
+        this.deleteChildren(getProvider().getRealPath(key), true);
+    }
+    
+    private void deleteChildren(final String path, final boolean deleteCurrentNode) throws KeeperException, InterruptedException {
+        LOGGER.debug("deleteChildren:{}", path);
+        List<String> children;
+        try {
+            children = getProvider().getChildren(path);
+        } catch (KeeperException.NoNodeException e) {
+            LOGGER.warn("deleteChildren node not exist:{},e:{}", path, e.getMessage());
+            return;
+        }
+        for (String child : children) {
+            this.deleteAllChildren(PathUtil.getRealPath(path, child));
+        }
+        if (deleteCurrentNode) {
+            try {
+                this.deleteOnlyCurrent(path);
+            } catch (KeeperException.NotEmptyException e) {
+                LOGGER.warn("deleteCurrentNode exist children:{},e:{}", path, e.getMessage());
+                deleteChildren(path, true);
+            } catch (KeeperException.NoNodeException e) {
+                LOGGER.warn("deleteCurrentNode node not exist:{},e:{}", path, e.getMessage());
+            }
+        }
+    }
+    
+    /*
+    * delete the current node with force and delete the super node whose only child node is current node recursively
+    */
+    @Override
+    public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
+        LOGGER.debug("deleteCurrentBranch:{}", key);
+        if (key.indexOf(Constants.PATH_SEPARATOR) < -1) {
+            this.deleteOnlyCurrent(key);
+            return;
+        }
+        String path = getProvider().getRealPath(key);
+        this.deleteChildren(path, true);
+        String superPath = path.substring(0, path.lastIndexOf(Constants.PATH_SEPARATOR));
+        try {
+            this.deleteRecursively(superPath);
+        } catch (KeeperException.NotEmptyException e) {
+            LOGGER.warn("deleteCurrentBranch exist children:{},e:{}", path, e.getMessage());
+        } catch (KeeperException.NoNodeException e) {
+            LOGGER.warn("deleteCurrentBranch NoNodeException:{},e:{}", superPath, e.getMessage());
+        }
+    }
+    
+    private void deleteRecursively(final String path) throws KeeperException, InterruptedException {
+        LOGGER.debug("deleteRecursively:{}", path);
+        int index = path.lastIndexOf(Constants.PATH_SEPARATOR);
+        if (index == 0) {
+            this.deleteOnlyCurrent(path);
+            return;
+        }
+        String superPath = path.substring(0, index);
+        try {
+            this.deleteOnlyCurrent(path);
+            this.deleteRecursively(superPath);
+        } catch (KeeperException.NotEmptyException e) {
+            LOGGER.warn("deleteRecursively exist children:{},e:{}", path, e.getMessage());
+            LOGGER.info("deleteRecursively {} exist other children:{}", path, this.getChildren(path));
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/transaction/ZKTransaction.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/transaction/ZKTransaction.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.transaction;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.Holder;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.OpResult;
+import org.apache.zookeeper.Transaction;
+import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/*
+ * @author lidongbo
+ * @since zookeeper 3.4.0
+ */
+public class ZKTransaction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZKTransaction.class);
+    
+    private final Transaction transaction;
+    
+    private final String rootNode;
+
+    public ZKTransaction(final String root, final Holder holder) {
+        transaction = holder.getZooKeeper().transaction();
+        rootNode = root;
+        LOGGER.debug("ZKTransaction root:{}", rootNode);
+    }
+    
+    /**
+     * create target node.
+     *
+     * @param path key
+     * @param data value
+     * @param acl acl
+     * @param createMode createMode
+     * @return ZKTransaction
+     */
+    public ZKTransaction create(final String path, final byte[] data, final List<ACL> acl, final CreateMode createMode) {
+        this.transaction.create(PathUtil.getRealPath(rootNode, path), data, acl, createMode);
+        LOGGER.debug("wait create:{},data:{},acl:{},createMode:{}", new Object[]{path, data, acl, createMode});
+        return this;
+    }
+    
+    /**
+     * delete target node.
+     *
+     * @param path key
+     * @return ZKTransaction
+     */
+    public ZKTransaction delete(final String path) {
+        return delete(path, Constants.VERSION);
+    }
+    
+    /**
+     * delete target node.
+     *
+     * @param path key
+     * @param version version
+     * @return ZKTransaction
+     */
+    public ZKTransaction delete(final String path, final int version) {
+        this.transaction.delete(PathUtil.getRealPath(rootNode, path), version);
+        LOGGER.debug("wait delete:{}", path);
+        return this;
+    }
+    
+    /**
+     * check target node.
+     *
+     * @param path key
+     * @return ZKTransaction
+     */
+    public ZKTransaction check(final String path) {
+        return check(path, Constants.VERSION);
+    }
+    
+    /**
+     * check target node.
+     *
+     * @param path key
+     * @param version version
+     * @return ZKTransaction
+     */
+    public ZKTransaction check(final String path, final int version) {
+        this.transaction.check(PathUtil.getRealPath(rootNode, path), version);
+        LOGGER.debug("wait check:{}", path);
+        return this;
+    }
+    
+    /**
+     * update target node.
+     *
+     * @param path key
+     * @param data data
+     * @return ZKTransaction
+     */
+    public ZKTransaction setData(final String path, final byte[] data) {
+        return setData(path, data, Constants.VERSION);
+    }
+    
+    /**
+     * update target node.
+     *
+     * @param path key
+     * @param data data
+     * @param version version
+     * @return ZKTransaction
+     */
+    public ZKTransaction setData(final String path, final byte[] data, final int version) {
+        this.transaction.setData(PathUtil.getRealPath(rootNode, path), data, version);
+        LOGGER.debug("wait setData:{},data:{}", path, data);
+        return this;
+    }
+    
+    /**
+     * commit.
+     *
+     * @return operation result
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public List<OpResult> commit() throws InterruptedException, KeeperException {
+        LOGGER.debug("ZKTransaction commit");
+        return this.transaction.commit();
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/zookeeper/ZookeeperConfiguration.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/zookeeper/ZookeeperConfiguration.java
@@ -73,4 +73,11 @@ public final class ZookeeperConfiguration implements RegistryCenterConfiguration
      * <p>Default is not need digest</p>
      */
     private String digest;
+    
+    /**
+     * RegCenter for zookeeper.
+     *
+     * <p>Default is ZookeeperRegistryCenter</p>
+     */
+    private boolean useNative;
 }


### PR DESCRIPTION
Fixes #717.

Changes proposed in this pull request:
-use transaction : support zookeeper 3.4.0+
-exclude transaction : support all zookeeper version, just version range is 3.3.0-3.3.6  need introduce slf4j
-open the native client like this : 

-----

orchestration:
  name: ******
  zookeeper:
    useNative: true
    namespace: ***********
.....

-----