### PR TITLE
sync retry needless reset connection should not throw exception

### DIFF
--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
@@ -81,7 +81,7 @@ public interface IClient extends IAction, IGroupAction {
      *
      * @return ZKTransaction
      */
-   ZKTransaction transaction();
+    ZKTransaction transaction();
     /*
     void createNamespace();
     void deleteNamespace();

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
@@ -87,7 +87,7 @@ public final class PathTree {
             return;
         }
         try {
-            if (status == status.RELEASE) {
+            if (status == PathStatus.RELEASE) {
                 LOGGER.debug("loading status:{}", status);
                 this.setStatus(PathStatus.CHANGING);
         
@@ -339,7 +339,7 @@ public final class PathTree {
             LOGGER.debug("cache put:{},value:{}", path, value);
             PathUtils.validatePath(path);
             LOGGER.debug("put status:{}", status);
-            if (status == status.RELEASE) {
+            if (status == PathStatus.RELEASE) {
                 if (path.equals(rootNode.get().getKey())) {
                     rootNode.set(new PathNode(rootNode.get().getKey(), value.getBytes(Constants.UTF_8)));
                     return;

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/Callable.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/Callable.java
@@ -80,8 +80,6 @@ public abstract class Callable<T> {
             delayPolicyExecutor.next();
             if (Connection.needReset(e)) {
                 provider.resetConnection();
-            } else {
-                throw e;
             }
             execDelay();
         } catch (InterruptedException e) {

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/Callable.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/Callable.java
@@ -15,11 +15,10 @@
  * </p>
  */
 
-package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section;
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
 
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
-import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayPolicyExecutor;
-import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Connection;
 import lombok.Setter;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
@@ -53,7 +53,7 @@ public class UsualClient extends BaseClient {
     private final boolean watched = true;
     
     @Getter
-    private io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IExecStrategy strategy;
+    private IExecStrategy strategy;
     
     UsualClient(final BaseContext context) {
         super(context);

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseOperation.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseOperation.java
@@ -80,10 +80,8 @@ public abstract class BaseOperation implements Delayed {
         } catch (KeeperException e) {
             if (Connection.needReset(e)) {
                 provider.resetConnection();
-                result = false;
-            } else {
-                throw e;
             }
+            result = false;
         }
         if (!result && delayPolicyExecutor.hasNext()) {
             delayPolicyExecutor.next();

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
@@ -42,10 +42,9 @@ public class Connection {
      * @param e e
      * @return need retry
      * @throws KeeperException Zookeeper Exception
-     * @throws InterruptedException InterruptedException
      */
     public static boolean needRetry(final KeeperException e) throws KeeperException {
-        return EXCEPTION_RESETS.containsKey(e);
+        return EXCEPTION_RESETS.containsKey(e.code().intValue());
     }
     
     /**
@@ -54,7 +53,6 @@ public class Connection {
      * @param e e
      * @return need reset
      * @throws KeeperException Zookeeper Exception
-     * @throws InterruptedException InterruptedException
      */
     public static boolean needReset(final KeeperException e) throws KeeperException {
         int code = e.code().intValue();

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/section/Connection.java
@@ -37,6 +37,18 @@ public class Connection {
     }
     
     /**
+     * need retry.
+     *
+     * @param e e
+     * @return need retry
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public static boolean needRetry(final KeeperException e) throws KeeperException {
+        return EXCEPTION_RESETS.containsKey(e);
+    }
+    
+    /**
      * need reset.
      *
      * @param e e

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
@@ -50,7 +50,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().create(path, value, createMode);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AsyncRetryStrategy SessionExpiredException createCurrentOnly:{}", path);
             AsyncRetryCenter.INSTANCE.add(new CreateCurrentOperation(getProvider(), path, value, createMode));
         }
@@ -61,7 +61,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().update(path, value);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AsyncRetryStrategy SessionExpiredException update:{}", path);
             AsyncRetryCenter.INSTANCE.add(new UpdateOperation(getProvider(), path, value));
         }
@@ -72,7 +72,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().delete(path);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AsyncRetryStrategy SessionExpiredException deleteOnlyCurrent:{}", path);
             AsyncRetryCenter.INSTANCE.add(new DeleteCurrentOperation(getProvider(), path));
         }
@@ -82,7 +82,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
         try {
             super.createAllNeedPath(key, value, createMode);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException CreateAllNeedOperation:{}", key);
             AsyncRetryCenter.INSTANCE.add(new CreateAllNeedOperation(getProvider(), key, value, createMode));
         }
@@ -92,7 +92,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
         try {
             super.deleteAllChildren(key);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteAllChildren:{}", key);
             AsyncRetryCenter.INSTANCE.add(new DeleteAllChildrenOperation(getProvider(), key));
         }
@@ -102,7 +102,7 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
         try {
             super.deleteCurrentBranch(key);
-        } catch (KeeperException.SessionExpiredException e) {
+        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
             LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteCurrentBranch:{}", key);
             AsyncRetryCenter.INSTANCE.add(new DeleteCurrentBranchOperation(getProvider(), key));
         }

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/AsyncRetryStrategy.java
@@ -26,6 +26,7 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.DeleteCurrentBranchOperation;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.DeleteCurrentOperation;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.operation.UpdateOperation;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Connection;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
@@ -50,9 +51,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().create(path, value, createMode);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AsyncRetryStrategy SessionExpiredException createCurrentOnly:{}", path);
-            AsyncRetryCenter.INSTANCE.add(new CreateCurrentOperation(getProvider(), path, value, createMode));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AsyncRetryStrategy SessionExpiredException createCurrentOnly:{}", path);
+                AsyncRetryCenter.INSTANCE.add(new CreateCurrentOperation(getProvider(), path, value, createMode));
+            } else {
+                throw e;
+            }
         }
     }
     
@@ -61,9 +66,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().update(path, value);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AsyncRetryStrategy SessionExpiredException update:{}", path);
-            AsyncRetryCenter.INSTANCE.add(new UpdateOperation(getProvider(), path, value));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AsyncRetryStrategy SessionExpiredException update:{}", path);
+                AsyncRetryCenter.INSTANCE.add(new UpdateOperation(getProvider(), path, value));
+            } else {
+                throw e;
+            }
         }
     }
     
@@ -72,9 +81,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
         String path = getProvider().getRealPath(key);
         try {
             getProvider().delete(path);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AsyncRetryStrategy SessionExpiredException deleteOnlyCurrent:{}", path);
-            AsyncRetryCenter.INSTANCE.add(new DeleteCurrentOperation(getProvider(), path));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AsyncRetryStrategy SessionExpiredException deleteOnlyCurrent:{}", path);
+                AsyncRetryCenter.INSTANCE.add(new DeleteCurrentOperation(getProvider(), path));
+            } else {
+                throw e;
+            }
         }
     }
     
@@ -82,9 +95,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void createAllNeedPath(final String key, final String value, final CreateMode createMode) throws KeeperException, InterruptedException {
         try {
             super.createAllNeedPath(key, value, createMode);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException CreateAllNeedOperation:{}", key);
-            AsyncRetryCenter.INSTANCE.add(new CreateAllNeedOperation(getProvider(), key, value, createMode));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException CreateAllNeedOperation:{}", key);
+                AsyncRetryCenter.INSTANCE.add(new CreateAllNeedOperation(getProvider(), key, value, createMode));
+            } else {
+                throw e;
+            }
         }
     }
     
@@ -92,9 +109,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void deleteAllChildren(final String key) throws KeeperException, InterruptedException {
         try {
             super.deleteAllChildren(key);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteAllChildren:{}", key);
-            AsyncRetryCenter.INSTANCE.add(new DeleteAllChildrenOperation(getProvider(), key));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteAllChildren:{}", key);
+                AsyncRetryCenter.INSTANCE.add(new DeleteAllChildrenOperation(getProvider(), key));
+            } else {
+                throw e;
+            }
         }
     }
     
@@ -102,9 +123,13 @@ public class AsyncRetryStrategy extends SyncRetryStrategy {
     public void deleteCurrentBranch(final String key) throws KeeperException, InterruptedException {
         try {
             super.deleteCurrentBranch(key);
-        } catch (KeeperException.SessionExpiredException | KeeperException.SessionMovedException e) {
-            LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteCurrentBranch:{}", key);
-            AsyncRetryCenter.INSTANCE.add(new DeleteCurrentBranchOperation(getProvider(), key));
+        } catch (KeeperException e) {
+            if (Connection.needRetry(e)) {
+                LOGGER.warn("AllAsyncRetryStrategy SessionExpiredException deleteCurrentBranch:{}", key);
+                AsyncRetryCenter.INSTANCE.add(new DeleteCurrentBranchOperation(getProvider(), key));
+            } else {
+                throw e;
+            }
         }
     }
 }

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
@@ -19,7 +19,7 @@ package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy
 
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
-import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Callable;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.Callable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.zookeeper.CreateMode;


### PR DESCRIPTION
Fixes #717.

Changes proposed in this pull request:
-Callable exec() remove else cause in KeeperException catch 
-
-
