### PR TITLE
 start(final int wait, final TimeUnit units) instead blockUntilConnected(final int wait, final TimeUnit units)

### DIFF
--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
@@ -32,7 +32,6 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.L
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.StrategyType;
 import io.shardingsphere.jdbc.orchestration.reg.zookeeper.ZookeeperConfiguration;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.ZooDefs;
 
@@ -74,12 +73,7 @@ public final class NewZookeeperRegistryCenter implements RegistryCenter {
     private IClient initClient(final ClientFactory creator, final ZookeeperConfiguration zkConfig) {
         IClient newClient = null;
         try {
-            newClient = creator.start();
-            // block, slowly
-            if (!newClient.blockUntilConnected(zkConfig.getMaxSleepTimeMilliseconds() * zkConfig.getMaxRetries(), TimeUnit.MILLISECONDS)) {
-                newClient.close();
-                throw new KeeperException.OperationTimeoutException();
-            }
+            newClient = creator.start(zkConfig.getMaxSleepTimeMilliseconds() * zkConfig.getMaxRetries(), TimeUnit.MILLISECONDS);
             newClient.useExecStrategy(StrategyType.SYNC_RETRY);
             // CHECKSTYLE:OFF
         } catch (Exception e) {

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/action/IClient.java
@@ -40,14 +40,15 @@ public interface IClient extends IAction, IGroupAction {
     void start() throws IOException, InterruptedException;
     
     /**
-     * block until connected.
+     * start until out.
      *
      * @param wait wait
      * @param units units
      * @return connected
+     * @throws IOException IO Exception
      * @throws InterruptedException InterruptedException
      */
-    boolean blockUntilConnected(int wait, TimeUnit units) throws InterruptedException;
+    boolean start(int wait, TimeUnit units) throws IOException, InterruptedException;
     
     /**
      * close.

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClient.java
@@ -55,7 +55,7 @@ public class UsualClient extends BaseClient {
     @Getter
     private IExecStrategy strategy;
     
-    UsualClient(final BaseContext context) {
+    protected UsualClient(final BaseContext context) {
         super(context);
     }
 

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
@@ -73,7 +73,13 @@ public abstract class BaseClient implements IClient {
     }
     
     @Override
-    public synchronized boolean blockUntilConnected(final int wait, final TimeUnit units) throws InterruptedException {
+    public synchronized boolean start(final int wait, final TimeUnit units) throws InterruptedException, IOException {
+        holder = new Holder(getContext());
+        holder.start(wait, units);
+        return holder.isConnected();
+    }
+    
+    private synchronized boolean blockUntilConnected(final int wait, final TimeUnit units) throws InterruptedException {
         long maxWait = units != null ? TimeUnit.MILLISECONDS.convert(wait, units) : 0;
 
         while (!holder.isConnected()) {
@@ -90,7 +96,9 @@ public abstract class BaseClient implements IClient {
     public void close() {
         context.close();
         try {
-            this.deleteNamespace();
+            if (rootExist) {
+                this.deleteNamespace();
+            }
             // CHECKSTYLE:OFF
         } catch (Exception e) {
             // CHECKSTYLE:ON

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClient.java
@@ -53,6 +53,7 @@ public abstract class BaseClient implements IClient {
     private boolean rootExist;
     
     @Getter(value = AccessLevel.PROTECTED)
+    @Setter(value = AccessLevel.PROTECTED)
     private Holder holder;
     
     @Setter(value = AccessLevel.PROTECTED)

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientFactory.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientFactory.java
@@ -22,11 +22,13 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.L
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /*
  * @author lidongbo
@@ -56,15 +58,38 @@ public abstract class BaseClientFactory {
      * @throws InterruptedException InterruptedException
      */
     public IClient start() throws IOException, InterruptedException {
+        prepareClient();
+        client.start();
+        return client;
+    }
+    
+    /**
+     * start until Timeout.
+     *
+     * @param wait wait
+     * @param units units
+     * @return connected
+     * @throws IOException IO Exception
+     * @throws InterruptedException InterruptedException
+     * @throws KeeperException OperationTimeoutException
+     */
+    public IClient start(final int wait, final TimeUnit units) throws IOException, InterruptedException, KeeperException {
+        prepareClient();
+        if (!client.start(wait, units)) {
+            client.close();
+            throw new KeeperException.OperationTimeoutException();
+        }
+        return client;
+    }
+    
+    private void prepareClient() {
         client.setRootNode(namespace);
         if (scheme == null) {
             authorities = ZooDefs.Ids.OPEN_ACL_UNSAFE;
         }
         client.setAuthorities(scheme, auth, authorities);
-        client.start();
         if (globalListener != null) {
             client.registerWatch(globalListener);
         }
-        return client;
     }
 }

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /*
  * zookeeper connection holder
@@ -60,13 +61,22 @@ public class Holder {
      * @throws InterruptedException InterruptedException
      */
     public void start() throws IOException, InterruptedException {
+        initZookeeper();
+        connectLatch.await();
+    }
+    
+    protected void start(final int wait, final TimeUnit units) throws IOException, InterruptedException {
+        initZookeeper();
+        connectLatch.await(wait, units);
+    }
+    
+    protected void initZookeeper() throws IOException {
         LOGGER.debug("Holder servers:{},sessionTimeOut:{}", context.getServers(), context.getSessionTimeOut());
         zooKeeper = new ZooKeeper(context.getServers(), context.getSessionTimeOut(), startWatcher());
         if (!io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.StringUtil.isNullOrBlank(context.getScheme())) {
             zooKeeper.addAuthInfo(context.getScheme(), context.getAuth());
             LOGGER.debug("Holder scheme:{},auth:{}", context.getScheme(), context.getAuth());
         }
-        connectLatch.await();
     }
     
     private Watcher startWatcher() {

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/Holder.java
@@ -21,6 +21,7 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
@@ -48,6 +49,7 @@ public class Holder {
     private ZooKeeper zooKeeper;
     
     @Getter
+    @Setter(value = AccessLevel.PROTECTED)
     private boolean connected;
     
     Holder(final BaseContext context) {
@@ -99,7 +101,7 @@ public class Holder {
         };
     }
     
-    private void processConnection(final WatchedEvent event) {
+    protected void processConnection(final WatchedEvent event) {
         LOGGER.debug("BaseClient process event:{}", event.toString());
         if (Watcher.Event.EventType.None == event.getType()) {
             if (Watcher.Event.KeeperState.SyncConnected == event.getState()) {

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
@@ -44,7 +44,7 @@ public class SyncRetryStrategy extends UsualStrategy {
     public SyncRetryStrategy(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
         super(provider);
         if (delayRetryPolicy == null) {
-            LOGGER.warn("Callable constructor context's delayRetryPolicy is null");
+            LOGGER.info("Callable constructor context's delayRetryPolicy is null");
             this.delayRetryPolicy = DelayRetryPolicy.newNoInitDelayPolicy();
         } else {
             this.delayRetryPolicy = delayRetryPolicy;

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClientTest;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Created by aaa
+ */
+public class UsualClientTest extends BaseClientTest {
+    
+    @Override
+    protected IClient createClient(final ClientFactory creator) throws IOException, InterruptedException {
+        return creator.setClientNamespace(ROOT).authorization(AUTH, AUTH.getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL).newClient(SERVERS, SESSION_TIMEOUT).start();
+    }
+    
+    @Test
+    public void createRoot() throws KeeperException, InterruptedException {
+        super.createRoot(testClient);
+    }
+    
+    @Test
+    public void createChild() throws KeeperException, InterruptedException {
+        super.createChild(testClient);
+    }
+    
+    @Test
+    public void deleteBranch() throws KeeperException, InterruptedException {
+        super.deleteBranch(testClient);
+    }
+    
+    @Test
+    public void isExisted() throws KeeperException, InterruptedException {
+        super.isExisted(testClient);
+    }
+    
+    @Test
+    public void get() throws KeeperException, InterruptedException {
+        super.get(testClient);
+    }
+    
+    @Test
+    public void asynGet() throws KeeperException, InterruptedException {
+        super.asynGet(testClient);
+    }
+    
+    @Test
+    public void getChildrenKeys() throws KeeperException, InterruptedException {
+        super.getChildrenKeys(testClient);
+    }
+    
+    @Test
+    public void persist() throws KeeperException, InterruptedException {
+        super.persist(testClient);
+    }
+    
+    @Test
+    public void persistEphemeral() throws KeeperException, InterruptedException {
+        super.persistEphemeral(testClient);
+    }
+    
+    @Test
+    public void delAllChildren() throws KeeperException, InterruptedException {
+        super.delAllChildren(testClient);
+    }
+    
+    @Test
+    public void watch() throws KeeperException, InterruptedException {
+        super.watch(testClient);
+    }
+    
+    @Test
+    public void close() throws Exception {
+        super.close(testClient);
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
@@ -21,6 +21,7 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClientTest;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.io.IOException;
 /**
  * Created by aaa
  */
+@Ignore
 public class UsualClientTest extends BaseClientTest {
     
     @Override

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
@@ -36,62 +36,62 @@ public class UsualClientTest extends BaseClientTest {
     }
     
     @Test
-    public void createRoot() throws KeeperException, InterruptedException {
+    public void assertCreateRoot() throws KeeperException, InterruptedException {
         super.createRoot(testClient);
     }
     
     @Test
-    public void createChild() throws KeeperException, InterruptedException {
+    public void assertCreateChild() throws KeeperException, InterruptedException {
         super.createChild(testClient);
     }
     
     @Test
-    public void deleteBranch() throws KeeperException, InterruptedException {
+    public void assertDeleteBranch() throws KeeperException, InterruptedException {
         super.deleteBranch(testClient);
     }
     
     @Test
-    public void isExisted() throws KeeperException, InterruptedException {
+    public void assertExisted() throws KeeperException, InterruptedException {
         super.isExisted(testClient);
     }
     
     @Test
-    public void get() throws KeeperException, InterruptedException {
+    public void assertGet() throws KeeperException, InterruptedException {
         super.get(testClient);
     }
     
     @Test
-    public void asynGet() throws KeeperException, InterruptedException {
+    public void assertAsynGet() throws KeeperException, InterruptedException {
         super.asynGet(testClient);
     }
     
     @Test
-    public void getChildrenKeys() throws KeeperException, InterruptedException {
+    public void assertGetChildrenKeys() throws KeeperException, InterruptedException {
         super.getChildrenKeys(testClient);
     }
     
     @Test
-    public void persist() throws KeeperException, InterruptedException {
+    public void assertPersist() throws KeeperException, InterruptedException {
         super.persist(testClient);
     }
     
     @Test
-    public void persistEphemeral() throws KeeperException, InterruptedException {
+    public void assertPersistEphemeral() throws KeeperException, InterruptedException {
         super.persistEphemeral(testClient);
     }
     
     @Test
-    public void delAllChildren() throws KeeperException, InterruptedException {
+    public void assertDelAllChildren() throws KeeperException, InterruptedException {
         super.delAllChildren(testClient);
     }
     
     @Test
-    public void watch() throws KeeperException, InterruptedException {
+    public void assertWatch() throws KeeperException, InterruptedException {
         super.watch(testClient);
     }
     
     @Test
-    public void close() throws Exception {
+    public void assertClose() throws Exception {
         super.close(testClient);
     }
 }

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 /**
  * Created by aaa
  */
-@Ignore
 public class UsualClientTest extends BaseClientTest {
     
     @Override

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/UsualClientTest.java
@@ -19,6 +19,7 @@ package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
 
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.BaseClientTest;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.TestSupport;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.junit.Ignore;
@@ -33,7 +34,8 @@ public class UsualClientTest extends BaseClientTest {
     
     @Override
     protected IClient createClient(final ClientFactory creator) throws IOException, InterruptedException {
-        return creator.setClientNamespace(ROOT).authorization(AUTH, AUTH.getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL).newClient(SERVERS, SESSION_TIMEOUT).start();
+        return creator.setClientNamespace(TestSupport.ROOT).authorization(TestSupport.AUTH, TestSupport.AUTH.getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL)
+                .newClient(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT).start();
     }
     
     @Test

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -31,6 +31,7 @@ import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,12 +46,13 @@ import java.util.concurrent.CountDownLatch;
 /**
  * Created by aaa
  */
+@Ignore
 public abstract class BaseClientTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
     
     protected static final String AUTH = "digest";
     
-    protected static final String SERVERS = "192.168.2.44:2181";
+    protected static final String SERVERS = "localhost:3181";
     
     protected static final int SESSION_TIMEOUT = 200000;//ms
     

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -47,12 +47,17 @@ import java.util.concurrent.CountDownLatch;
  */
 public abstract class BaseClientTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
-    public static final String AUTH = "digest";
-    public static final String SERVERS = "192.168.2.44:2181";
-    public static final int SESSION_TIMEOUT = 200000;//ms
-    public static final String ROOT = "test";
+    
+    protected static final String AUTH = "digest";
+    
+    protected static final String SERVERS = "192.168.2.44:2181";
+    
+    protected static final int SESSION_TIMEOUT = 200000;//ms
+    
+    protected static final String ROOT = "test";
     
     protected IClient testClient = null;
+    
     protected ZooKeeper zooKeeper;
     
     @Before
@@ -76,7 +81,7 @@ public abstract class BaseClientTest {
     }
     
     @Test
-    public void deleteRoot() throws KeeperException, InterruptedException {
+    public void assertDeleteRoot() throws KeeperException, InterruptedException {
         ((BaseClient)testClient).createNamespace();
         deleteRoot(testClient);
         assert getZooKeeper(testClient).exists(Constants.PATH_SEPARATOR + ROOT, false) == null;

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.ClientFactory;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Created by aaa
+ */
+public abstract class BaseClientTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
+    public static final String AUTH = "digest";
+    public static final String SERVERS = "192.168.2.44:2181";
+    public static final int SESSION_TIMEOUT = 200000;//ms
+    public static final String ROOT = "test";
+    
+    protected IClient testClient = null;
+    protected ZooKeeper zooKeeper;
+    
+    @Before
+    public void start() throws IOException, InterruptedException {
+        ClientFactory creator = new ClientFactory();
+        testClient = createClient(creator);
+        getZooKeeper(testClient);
+    }
+    
+    protected ZooKeeper getZooKeeper(IClient client){
+        zooKeeper = ((BaseClient)client).getHolder().getZooKeeper();
+        return zooKeeper;
+    }
+    
+    protected abstract IClient createClient(ClientFactory creator) throws IOException, InterruptedException;
+    
+    @After
+    public void stop() throws InterruptedException {
+        testClient.close();
+        testClient = null;
+    }
+    
+    @Test
+    public void deleteRoot() throws KeeperException, InterruptedException {
+        ((BaseClient)testClient).createNamespace();
+        deleteRoot(testClient);
+        assert getZooKeeper(testClient).exists(Constants.PATH_SEPARATOR + ROOT, false) == null;
+    }
+    
+    protected void createRootOnly(IClient client) throws KeeperException, InterruptedException {
+        ((BaseClient)client).createNamespace();
+    }
+    
+    protected void deleteRoot(IClient client) throws KeeperException, InterruptedException {
+        ((BaseClient)client).deleteNamespace();
+    }
+    
+    protected void createRoot(IClient client) throws KeeperException, InterruptedException {
+        ((BaseClient)client).createNamespace();
+        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + ROOT, false) != null;
+        ((BaseClient)client).deleteNamespace();
+        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + ROOT, false) == null;
+    }
+    
+    protected void createChild(IClient client) throws KeeperException, InterruptedException {
+        String key = "a/b/bb";
+        client.createAllNeedPath(key, "bbb11", CreateMode.PERSISTENT);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key)/*"/" + ROOT + "/" + key*/, false) != null;
+        client.deleteCurrentBranch(key);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key)/*"/" + ROOT + "/" + key*/, false) == null;
+    }
+    
+    protected void deleteBranch(IClient client) throws KeeperException, InterruptedException {
+        String keyB = "a/b/bb";
+        client.createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyB), false) != null;
+        String keyC  = "a/c/cc";
+        client.createAllNeedPath(keyC, "ccc11", CreateMode.PERSISTENT);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyC), false) != null;
+        client.deleteCurrentBranch(keyC);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyC), false) == null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, "a"), false) != null;
+        client.deleteCurrentBranch(keyB);
+        assert getZooKeeper(client).exists(PathUtil.checkPath(ROOT), false) == null;
+        client.createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyB), false) != null;
+        client.deleteCurrentBranch(keyB);
+        assert getZooKeeper(client).exists(PathUtil.checkPath(ROOT), false) == null;
+    }
+    
+    protected void isExisted(IClient client) throws KeeperException, InterruptedException {
+        String key = "a/b/bb";
+        client.createAllNeedPath(key, "", CreateMode.PERSISTENT);
+        assert isExisted(key, client);
+        client.deleteCurrentBranch(key);
+    }
+    
+    protected void get(IClient client) throws KeeperException, InterruptedException {
+        client.createAllNeedPath("a/b", "bbb11", CreateMode.PERSISTENT);
+        String key = "a";
+        assert getDirectly(key, client).equals("");
+        key = "a/b";
+        assert getDirectly(key, client).equals("bbb11");
+        client.deleteCurrentBranch("a/b");
+    }
+    
+    protected void asynGet(IClient client) throws KeeperException, InterruptedException {
+        final CountDownLatch ready = new CountDownLatch(1);
+        String key = "a/b";
+        String value = "bbb11";
+        client.createAllNeedPath(key, value, CreateMode.PERSISTENT);
+        AsyncCallback.DataCallback callback = new AsyncCallback.DataCallback() {
+            @Override
+            public void processResult(int rc, String path, Object ctx, byte[] data, Stat stat) {
+                String result = new String(data);
+                LOGGER.info(new StringBuffer().append("rc:").append(rc).append(",path:").append(path).append(",ctx:").append(ctx).append(",stat:").append(stat).toString());
+                assert result.equals(ctx);
+                ready.countDown();
+            }
+        };
+        client.getData(key, callback, value);
+        ready.await();
+        client.deleteCurrentBranch("a/b");
+    }
+    
+    private String getDirectly(String key, IClient client) throws KeeperException, InterruptedException {
+        return new String(client.getData(key));
+    }
+    
+    private boolean isExisted(String key, IClient client) throws KeeperException, InterruptedException {
+        return client.checkExists(key);
+    }
+    
+    protected void getChildrenKeys(IClient client) throws KeeperException, InterruptedException {
+        String key = "a/b";
+        String current = "a";
+        client.createAllNeedPath(key, "", CreateMode.PERSISTENT);
+        List<String> result = client.getChildren(current);
+        Collections.sort(result, new Comparator<String>() {
+            public int compare(final String o1, final String o2) {
+                return o2.compareTo(o1);
+            }
+        });
+        assert result.get(0).equals("b");
+        client.deleteCurrentBranch(key);
+    }
+    
+    protected void persist(IClient client) throws KeeperException, InterruptedException {
+        String key = "a";
+        String value = "aa";
+        String newValue = "aaa";
+        if (!isExisted(key, client)) {
+            client.createAllNeedPath(key, value, CreateMode.PERSISTENT);
+        } else {
+            updateWithCheck(key, value, client);
+        }
+        
+        assert getDirectly(key, client).equals(value);
+    
+        updateWithCheck(key, newValue, client);
+        assert getDirectly(key, client).equals(newValue);
+        client.deleteCurrentBranch(key);
+    }
+    
+    private void updateWithCheck(String key, String value, IClient client) throws KeeperException, InterruptedException {
+        client.update(key, value);
+//        client.transaction().check(key, Constants.VERSION).setData(key, value.getBytes(Constants.UTF_8), Constants.VERSION).commit();
+    }
+    
+    protected void persistEphemeral(IClient client) throws KeeperException, InterruptedException {
+        String key = "a/b/bb";
+        String value = "b1b";
+        client.createAllNeedPath(key, value, CreateMode.PERSISTENT);
+//        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), null).getEphemeralOwner() == 0;
+        Stat stat = new Stat();
+        getZooKeeper(client).getData(PathUtil.getRealPath(ROOT, key), false, stat);
+        assert  stat.getEphemeralOwner() == 0;
+        
+        client.deleteAllChildren(key);
+        assert !isExisted(key, client);
+        client.createAllNeedPath(key, value, CreateMode.EPHEMERAL);
+        
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), null).getEphemeralOwner() != 0; // Ephemeral node connection session id
+        client.deleteCurrentBranch(key);
+    }
+    
+    protected void delAllChildren(IClient client) throws KeeperException, InterruptedException {
+        String key = "a/b/bb";
+        client.createAllNeedPath(key, "bb", CreateMode.PERSISTENT);
+        key = "a/c/cc";
+        client.createAllNeedPath(key, "cc", CreateMode.PERSISTENT);
+        LOGGER.debug("getNumChildren:" + getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, "a"), null).getNumChildren()); // nearest children count
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), false) != null;
+        client.deleteAllChildren("a");
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), false) == null;
+        assert getZooKeeper(client).exists("/" + ROOT, false) != null;
+        ((BaseClient)client).deleteNamespace();
+    }
+    
+    protected void watch(IClient client) throws KeeperException, InterruptedException {
+        List<String> expected = new ArrayList<>();
+        expected.add("update_/test/a_value");
+        expected.add("update_/test/a_value1");
+        expected.add("update_/test/a_value2");
+        expected.add("delete_/test/a_");
+        List<String> actual = new ArrayList<>();
+        
+        final Listener listener = buildListener(client, actual);
+        
+        String key = "a";
+        client.registerWatch(key, listener);
+        client.createCurrentOnly(key, "aaa", CreateMode.EPHEMERAL);
+        client.checkExists(key, new Watcher() {
+            @Override
+            public void process(WatchedEvent event) {
+                listener.process(event);
+            }
+        });
+        client.update(key, "value");
+        LOGGER.info(new String(client.getData(key)));
+        assert client.getDataString(key).equals("value");
+        client.update(key, "value1");
+        assert client.getDataString(key).equals("value1");
+        client.update(key, "value2");
+        assert client.getDataString(key).equals("value2");
+        Thread.sleep(100);
+        client.deleteCurrentBranch(key);
+        assert expected.size() == actual.size();
+        //The acquisition value is after the reception of the event,
+        //so the value may be not equal.
+        assert expected.containsAll(actual);
+        client.unregisterWatch(listener.getKey());
+    }
+    
+    protected Listener buildListener(final IClient client, final List<String> actual){
+        Listener listener = new Listener(null) {
+            @Override
+            public void process(WatchedEvent event) {
+                LOGGER.info(event.getPath());
+                LOGGER.info(event.getType().name());
+                
+                switch (event.getType()) {
+                    case NodeDataChanged:
+                    case NodeChildrenChanged: {
+                        String result;
+                        try {
+                            result = new String(getZooKeeper(client).getData(event.getPath(),false, null));
+                            LOGGER.info(result);
+                        } catch (KeeperException e) {
+                            result = e.getMessage();
+                            e.printStackTrace();
+                        } catch (InterruptedException e) {
+                            result = e.getMessage();
+                            e.printStackTrace();
+                        }
+                        actual.add(new StringBuilder().append("update_").append(event.getPath()).append("_").append(result).toString());
+                        break;
+                    }
+                    case NodeDeleted: {
+                        actual.add(new StringBuilder().append("delete_").append(event.getPath()).append("_").toString());
+                        break;
+                    }
+                    default:
+                        actual.add(new StringBuilder().append("ignore_").append(event.getPath()).append("_").append(event.getType()).toString());
+                        break;
+                }
+            }
+        };
+        return listener;
+    }
+    
+    protected void close(IClient client) throws Exception {
+        client.close();
+        assert getZooKeeper(client).getState() == ZooKeeper.States.CLOSED;
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -50,14 +50,6 @@ import java.util.concurrent.CountDownLatch;
 public abstract class BaseClientTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
     
-    protected static final String AUTH = "digest";
-    
-    protected static final String SERVERS = "localhost:3181";
-    
-    protected static final int SESSION_TIMEOUT = 200000;//ms
-    
-    protected static final String ROOT = "test";
-    
     protected IClient testClient = null;
     
     protected ZooKeeper zooKeeper;
@@ -87,7 +79,7 @@ public abstract class BaseClientTest {
     public void assertDeleteRoot() throws KeeperException, InterruptedException {
         ((BaseClient)testClient).createNamespace();
         deleteRoot(testClient);
-        assert getZooKeeper(testClient).exists(Constants.PATH_SEPARATOR + ROOT, false) == null;
+        assert getZooKeeper(testClient).exists(Constants.PATH_SEPARATOR + TestSupport.ROOT, false) == null;
     }
     
     protected void createRootOnly(IClient client) throws KeeperException, InterruptedException {
@@ -100,35 +92,35 @@ public abstract class BaseClientTest {
     
     protected void createRoot(IClient client) throws KeeperException, InterruptedException {
         ((BaseClient)client).createNamespace();
-        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + ROOT, false) != null;
+        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + TestSupport.ROOT, false) != null;
         ((BaseClient)client).deleteNamespace();
-        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + ROOT, false) == null;
+        assert getZooKeeper(client).exists(Constants.PATH_SEPARATOR + TestSupport.ROOT, false) == null;
     }
     
     protected void createChild(IClient client) throws KeeperException, InterruptedException {
         String key = "a/b/bb";
         client.createAllNeedPath(key, "bbb11", CreateMode.PERSISTENT);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key)/*"/" + ROOT + "/" + key*/, false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, key)/*"/" + ROOT + "/" + key*/, false) != null;
         client.deleteCurrentBranch(key);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key)/*"/" + ROOT + "/" + key*/, false) == null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, key)/*"/" + ROOT + "/" + key*/, false) == null;
     }
     
     protected void deleteBranch(IClient client) throws KeeperException, InterruptedException {
         String keyB = "a/b/bb";
         client.createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyB), false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, keyB), false) != null;
         String keyC  = "a/c/cc";
         client.createAllNeedPath(keyC, "ccc11", CreateMode.PERSISTENT);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyC), false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, keyC), false) != null;
         client.deleteCurrentBranch(keyC);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyC), false) == null;
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, "a"), false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, keyC), false) == null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, "a"), false) != null;
         client.deleteCurrentBranch(keyB);
-        assert getZooKeeper(client).exists(PathUtil.checkPath(ROOT), false) == null;
+        assert getZooKeeper(client).exists(PathUtil.checkPath(TestSupport.ROOT), false) == null;
         client.createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, keyB), false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, keyB), false) != null;
         client.deleteCurrentBranch(keyB);
-        assert getZooKeeper(client).exists(PathUtil.checkPath(ROOT), false) == null;
+        assert getZooKeeper(client).exists(PathUtil.checkPath(TestSupport.ROOT), false) == null;
     }
     
     protected void isExisted(IClient client) throws KeeperException, InterruptedException {
@@ -216,14 +208,14 @@ public abstract class BaseClientTest {
         client.createAllNeedPath(key, value, CreateMode.PERSISTENT);
 //        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), null).getEphemeralOwner() == 0;
         Stat stat = new Stat();
-        getZooKeeper(client).getData(PathUtil.getRealPath(ROOT, key), false, stat);
+        getZooKeeper(client).getData(PathUtil.getRealPath(TestSupport.ROOT, key), false, stat);
         assert  stat.getEphemeralOwner() == 0;
         
         client.deleteAllChildren(key);
         assert !isExisted(key, client);
         client.createAllNeedPath(key, value, CreateMode.EPHEMERAL);
         
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), null).getEphemeralOwner() != 0; // Ephemeral node connection session id
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, key), null).getEphemeralOwner() != 0; // Ephemeral node connection session id
         client.deleteCurrentBranch(key);
     }
     
@@ -232,11 +224,11 @@ public abstract class BaseClientTest {
         client.createAllNeedPath(key, "bb", CreateMode.PERSISTENT);
         key = "a/c/cc";
         client.createAllNeedPath(key, "cc", CreateMode.PERSISTENT);
-        LOGGER.debug("getNumChildren:" + getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, "a"), null).getNumChildren()); // nearest children count
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), false) != null;
+        LOGGER.debug("getNumChildren:" + getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, "a"), null).getNumChildren()); // nearest children count
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, key), false) != null;
         client.deleteAllChildren("a");
-        assert getZooKeeper(client).exists(PathUtil.getRealPath(ROOT, key), false) == null;
-        assert getZooKeeper(client).exists("/" + ROOT, false) != null;
+        assert getZooKeeper(client).exists(PathUtil.getRealPath(TestSupport.ROOT, key), false) == null;
+        assert getZooKeeper(client).exists("/" + TestSupport.ROOT, false) != null;
         ((BaseClient)client).deleteNamespace();
     }
     

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -22,6 +22,7 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.Constants;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.ClientFactory;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Listener;
+import io.shardingsphere.jdbc.orchestration.util.EmbedTestingServer;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -46,7 +47,6 @@ import java.util.concurrent.CountDownLatch;
 /**
  * Created by aaa
  */
-@Ignore
 public abstract class BaseClientTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseClient.class);
     
@@ -64,6 +64,7 @@ public abstract class BaseClientTest {
     
     @Before
     public void start() throws IOException, InterruptedException {
+        EmbedTestingServer.start();
         ClientFactory creator = new ClientFactory();
         testClient = createClient(creator);
         getZooKeeper(testClient);

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/StartWaitTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/StartWaitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.ClientContext;
+import io.shardingsphere.jdbc.orchestration.util.EmbedTestingServer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * Created by aaa
+ */
+public class StartWaitTest {
+    @Before
+    public void start() throws IOException, InterruptedException {
+        EmbedTestingServer.start();
+    }
+    
+    @Test
+    public void testStart() throws IOException, InterruptedException {
+        IClient testClient = new TestClient(new ClientContext(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT));
+        boolean result = testClient.start(10000, TimeUnit.MILLISECONDS);
+        assert result;
+        System.out.println(result);
+        testClient.close();
+    }
+    
+    @Test
+    public void testSortStart() throws IOException, InterruptedException {
+        TestClient testClient = new TestClient(new ClientContext(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT));
+        boolean result = testClient.start(100, TimeUnit.MILLISECONDS);
+        assert !result;
+        System.out.println(result);
+        testClient.close();
+    }
+    
+    @Test
+    public void testNotStart() throws IOException, InterruptedException {
+        TestClient c = new TestClient(new ClientContext(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT));
+        boolean r = c.start(100, TimeUnit.MILLISECONDS);
+        System.out.println("result : " + r);
+        assert !r;
+        c.close();
+        assert !c.getZookeeper().getState().isConnected();
+        
+        System.out.println("===============================================================================");
+    
+        TestClient c1 = new TestClient(new ClientContext(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT));
+        boolean r1 = c1.start(10000, TimeUnit.MILLISECONDS);
+        System.out.println("result : " + r1);
+        assert r1;
+        c1.close();
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestClient.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestClient.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.UsualClient;
+import org.apache.zookeeper.ZooKeeper;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * Created by aaa
+ */
+public class TestClient extends UsualClient {
+    TestClient(BaseContext context) {
+        super(context);
+    }
+    
+    @Override
+    public synchronized boolean start(final int wait, final TimeUnit units) throws InterruptedException, IOException {
+        setHolder(new TestHolder(getContext()));
+        getHolder().start(wait, units);
+        return getHolder().isConnected();
+    }
+    
+    public ZooKeeper getZookeeper() {
+        return getHolder().getZooKeeper();
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestHolder.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestHolder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by aaa
+ */
+public class TestHolder extends Holder {
+    private final CountDownLatch CONNECTING = new CountDownLatch(1);
+    
+    public TestHolder(final BaseContext context) {
+        super(context);
+    }
+    
+    @Override
+    protected void start(final int wait, final TimeUnit units) throws IOException, InterruptedException {
+        initZookeeper();
+        System.out.println("begin start await0:" + this.isConnected());
+        CONNECTING.await(wait, units);
+        System.out.println("await:"+ wait);
+        System.out.println("start connected0:" + this.isConnected());
+    }
+    
+    @Override
+    protected void processConnection(final WatchedEvent event) {
+        if (Watcher.Event.EventType.None == event.getType()) {
+            if (Watcher.Event.KeeperState.SyncConnected == event.getState()) {
+                try {
+                    System.out.println("begin processConnection wait0:" + this.isConnected() + " ThreadId : " + Thread.currentThread().getId());
+                    Thread.sleep(1000);
+                    System.out.println("processConnection done. ThreadId : " + Thread.currentThread().getId());
+                } catch (Exception e) {
+                    System.out.println("wait " + e.getMessage());
+                }
+                this.setConnected(true);
+                System.out.println("processConnection connected0:" + this.isConnected());
+                CONNECTING.countDown();
+                return;
+            }
+        }
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
+
+/*
+ * Created by aaa
+ */
+public class TestSupport {
+    public static final String AUTH = "digest";
+    
+    public static final String SERVERS = "192.168.2.44:2181";
+    
+    public static final int SESSION_TIMEOUT = 200000;//ms
+    
+    public static final String ROOT = "test";
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
@@ -23,7 +23,7 @@ package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
 public class TestSupport {
     public static final String AUTH = "digest";
     
-    public static final String SERVERS = "192.168.2.44:2181";
+    public static final String SERVERS = "localhost:3181";
     
     public static final int SESSION_TIMEOUT = 200000;//ms
     


### PR DESCRIPTION
Fixes #717 
Changes proposed in this pull request:
- start(final int wait, final TimeUnit units) instead blockUntilConnected(final int wait, final TimeUnit units)
- usual client test
- sync retry strategy log level
