### PR TITLE
when packets read the character '0xfb', the length of packet will be 0.

### DIFF
--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/MySQLPacketPayload.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/MySQLPacketPayload.java
@@ -173,8 +173,11 @@ public final class MySQLPacketPayload {
      */
     public long readIntLenenc() {
         int firstByte = readInt1();
-        if (firstByte <= 0xfb) {
+        if (firstByte < 0xfb) {
             return firstByte;
+        }
+        if (0xfb == firstByte) {
+            return 0;
         }
         if (0xfc == firstByte) {
             return byteBuf.readShortLE();


### PR DESCRIPTION
- When the mysql backend response packets read the character '0xfb', the length of packet will be 0.
-
-
