### PR TITLE
use execute instead of executeQuery in getTableNamesFromDefaultDataSo…

### DIFF
--- a/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/MySQLShardingMetaDataHandler.java
+++ b/sharding-jdbc/src/main/java/io/shardingsphere/core/jdbc/metadata/dialect/MySQLShardingMetaDataHandler.java
@@ -69,7 +69,7 @@ public final class MySQLShardingMetaDataHandler extends ShardingMetaDataHandler 
         Collection<String> result = new LinkedList<>();
         try (Connection connection = getDataSource().getConnection();
              Statement statement = connection.createStatement()) {
-            statement.executeQuery("show tables;");
+            statement.execute("show tables;");
             try (ResultSet resultSet = statement.getResultSet()) {
                 while (resultSet.next()) {
                     result.add(resultSet.getString(1));


### PR DESCRIPTION
Hi!

Similarly to what happened in #852, the usage of `executeQuery` when retrieving the tables metadata in `MySQLShardingMetaDataHandler.getTableNamesFromDefaultDataSource` broke the application startup when using c3p0 as thread pool.

Cheers!

### Changes proposed in this pull request:
- Use `execute` instead of `executeQuery` in `MySQLShardingMetaDataHandler.getTableNamesFromDefaultDataSource`
