### PR TITLE
 make PreparedStatementRegistry thread safe

### DIFF
--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
@@ -39,9 +39,7 @@ public final class PreparedStatementRegistry {
     
     private final ConcurrentMap<String, Integer> sqlToStatementIdMap = new ConcurrentHashMap<>(65535, 1);
     
-    private final ConcurrentMap<Integer, String> statementIdToSQLMap = new ConcurrentHashMap<>(65535, 1);
-    
-    private final ConcurrentMap<Integer, List<PreparedStatementParameterHeader>> statementIdToParameterHeadersMap = new ConcurrentHashMap<>(65535, 1);
+    private final ConcurrentMap<Integer, SQLElement> statementIdToSQLElementMap = new ConcurrentHashMap<>(65535, 1);
     
     private final AtomicInteger sequence = new AtomicInteger();
     
@@ -64,7 +62,7 @@ public final class PreparedStatementRegistry {
         int statementId = sequence.incrementAndGet();
         Integer previousStatementId = sqlToStatementIdMap.putIfAbsent(sql, statementId);
         if (null == previousStatementId) {
-            statementIdToSQLMap.putIfAbsent(statementId, sql);
+            statementIdToSQLElementMap.putIfAbsent(statementId, new SQLElement(sql));
         } else {
             return previousStatementId;
         }
@@ -78,7 +76,7 @@ public final class PreparedStatementRegistry {
      * @return SQL
      */
     public String getSQL(final int statementId) {
-        return statementIdToSQLMap.get(statementId);
+        return statementIdToSQLElementMap.get(statementId).getSql();
     }
     
     /**
@@ -88,7 +86,7 @@ public final class PreparedStatementRegistry {
      * @param preparedStatementParameterHeaders prepared statement parameter headers
      */
     public void setParameterHeaders(final int statementId, final List<PreparedStatementParameterHeader> preparedStatementParameterHeaders) {
-        statementIdToParameterHeadersMap.putIfAbsent(statementId, preparedStatementParameterHeaders);
+        statementIdToSQLElementMap.get(statementId).setPreparedStatementParameterHeaders(preparedStatementParameterHeaders);
     }
     
     /**
@@ -98,6 +96,6 @@ public final class PreparedStatementRegistry {
      * @return prepared statement parameters
      */
     public PreparedStatementParameterHeader getParameterHeader(final int statementId) {
-        return statementIdToParameterHeadersMap.get(statementId).iterator().next();
+        return statementIdToSQLElementMap.get(statementId).getPreparedStatementParameterHeaders().iterator().next();
     }
 }

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
@@ -95,7 +95,7 @@ public final class PreparedStatementRegistry {
      * @param statementId statement ID
      * @return prepared statement parameters
      */
-    public PreparedStatementParameterHeader getParameterHeader(final int statementId) {
-        return statementIdToPreparedStatementUnitMap.get(statementId).getPreparedStatementParameterHeaders().iterator().next();
+    public List<PreparedStatementParameterHeader> getParameterHeader(final int statementId) {
+        return statementIdToPreparedStatementUnitMap.get(statementId).getPreparedStatementParameterHeaders();
     }
 }

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Prepared statement registry.
  *
  * @author zhangliang
+ * @author zhangyonglun
  */
 @NoArgsConstructor(access = AccessLevel.NONE)
 public final class PreparedStatementRegistry {
@@ -59,15 +60,14 @@ public final class PreparedStatementRegistry {
      * @param sql SQL
      * @return statement ID
      */
-    // TODO :yonglun thread not safe?
     public int register(final String sql) {
-        Integer result = sqlToStatementIdMap.get(sql);
-        if (null != result) {
-            return result;
-        }
         int statementId = sequence.incrementAndGet();
-        statementIdToSQLMap.putIfAbsent(statementId, sql);
-        sqlToStatementIdMap.putIfAbsent(sql, statementId);
+        Integer previousStatementId = sqlToStatementIdMap.putIfAbsent(sql, statementId);
+        if (null == previousStatementId) {
+            statementIdToSQLMap.putIfAbsent(statementId, sql);
+        } else {
+            return previousStatementId;
+        }
         return statementId;
     }
     

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementRegistry.java
@@ -39,7 +39,7 @@ public final class PreparedStatementRegistry {
     
     private final ConcurrentMap<String, Integer> sqlToStatementIdMap = new ConcurrentHashMap<>(65535, 1);
     
-    private final ConcurrentMap<Integer, SQLElement> statementIdToSQLElementMap = new ConcurrentHashMap<>(65535, 1);
+    private final ConcurrentMap<Integer, PreparedStatementUnit> statementIdToPreparedStatementUnitMap = new ConcurrentHashMap<>(65535, 1);
     
     private final AtomicInteger sequence = new AtomicInteger();
     
@@ -62,7 +62,7 @@ public final class PreparedStatementRegistry {
         int statementId = sequence.incrementAndGet();
         Integer previousStatementId = sqlToStatementIdMap.putIfAbsent(sql, statementId);
         if (null == previousStatementId) {
-            statementIdToSQLElementMap.putIfAbsent(statementId, new SQLElement(sql));
+            statementIdToPreparedStatementUnitMap.putIfAbsent(statementId, new PreparedStatementUnit(sql));
         } else {
             return previousStatementId;
         }
@@ -76,7 +76,7 @@ public final class PreparedStatementRegistry {
      * @return SQL
      */
     public String getSQL(final int statementId) {
-        return statementIdToSQLElementMap.get(statementId).getSql();
+        return statementIdToPreparedStatementUnitMap.get(statementId).getSql();
     }
     
     /**
@@ -86,7 +86,7 @@ public final class PreparedStatementRegistry {
      * @param preparedStatementParameterHeaders prepared statement parameter headers
      */
     public void setParameterHeaders(final int statementId, final List<PreparedStatementParameterHeader> preparedStatementParameterHeaders) {
-        statementIdToSQLElementMap.get(statementId).setPreparedStatementParameterHeaders(preparedStatementParameterHeaders);
+        statementIdToPreparedStatementUnitMap.get(statementId).setPreparedStatementParameterHeaders(preparedStatementParameterHeaders);
     }
     
     /**
@@ -96,6 +96,6 @@ public final class PreparedStatementRegistry {
      * @return prepared statement parameters
      */
     public PreparedStatementParameterHeader getParameterHeader(final int statementId) {
-        return statementIdToSQLElementMap.get(statementId).getPreparedStatementParameterHeaders().iterator().next();
+        return statementIdToPreparedStatementUnitMap.get(statementId).getPreparedStatementParameterHeaders().iterator().next();
     }
 }

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementUnit.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementUnit.java
@@ -32,7 +32,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Getter
 @Setter
-public class SQLElement {
+public class PreparedStatementUnit {
     
     private final String sql;
     

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementUnit.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/PreparedStatementUnit.java
@@ -32,7 +32,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Getter
 @Setter
-public class PreparedStatementUnit {
+public final class PreparedStatementUnit {
     
     private final String sql;
     

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/SQLElement.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/SQLElement.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.proxy.transport.mysql.packet.command.query.binary;
+
+import io.shardingsphere.proxy.transport.mysql.packet.command.query.binary.execute.PreparedStatementParameterHeader;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * SQL element.
+ *
+ * @author zhangyonglun
+ */
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class SQLElement {
+    
+    private final String sql;
+    
+    private List<PreparedStatementParameterHeader> preparedStatementParameterHeaders;
+}

--- a/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/execute/ComStmtExecutePacket.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/proxy/transport/mysql/packet/command/query/binary/execute/ComStmtExecutePacket.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -119,12 +120,13 @@ public final class ComStmtExecutePacket implements QueryCommandPacket {
     }
     
     private void setParameterHeaderFromCache(final int numParameters) {
+        Iterator<PreparedStatementParameterHeader> preparedStatementParameterHeaderIterator = PREPARED_STATEMENT_REGISTRY.getParameterHeader(statementId).iterator();
         for (int i = 0; i < numParameters; i++) {
             if (nullBitmap.isParameterNull(i)) {
                 preparedStatementParameters.add(new PreparedStatementParameter(NULL_PARAMETER_DEFAULT_COLUMN_TYPE, NULL_PARAMETER_DEFAULT_UNSIGNED_FLAG, null));
                 continue;
             }
-            PreparedStatementParameterHeader preparedStatementParameterHeader = PREPARED_STATEMENT_REGISTRY.getParameterHeader(statementId);
+            PreparedStatementParameterHeader preparedStatementParameterHeader = preparedStatementParameterHeaderIterator.next();
             preparedStatementParameters.add(new PreparedStatementParameter(preparedStatementParameterHeader.getColumnType(), preparedStatementParameterHeader.getUnsignedFlag()));
         }
     }


### PR DESCRIPTION
Changes:
1. make PreparedStatementRegistry thread safe.
2. combine SQL and parameters.
3. parameters repeatly updating will be prevented by jdbc mechanism automatically.

Tests:
example/CLI/GUI