### PR TITLE
Fixes a todo and sync retry strategy unit test

### DIFF
--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/NewZookeeperRegistryCenter.java
@@ -56,12 +56,12 @@ public final class NewZookeeperRegistryCenter implements RegistryCenter {
     private final Map<String, PathTree> caches = new HashMap<>();
     
     public NewZookeeperRegistryCenter(final ZookeeperConfiguration zkConfig) {
-        ClientFactory creator = buildCreator(zkConfig);
+        final ClientFactory creator = buildCreator(zkConfig);
         client = initClient(creator, zkConfig);
     }
     
     private ClientFactory buildCreator(final ZookeeperConfiguration zkConfig) {
-        ClientFactory creator = new ClientFactory();
+        final ClientFactory creator = new ClientFactory();
         creator.setClientNamespace(zkConfig.getNamespace())
                 .newClient(zkConfig.getServerLists(), zkConfig.getSessionTimeoutMilliseconds())
                 .setRetryPolicy(new DelayRetryPolicy(zkConfig.getBaseSleepTimeMilliseconds(), zkConfig.getMaxRetries(), zkConfig.getMaxSleepTimeMilliseconds()));
@@ -91,7 +91,7 @@ public final class NewZookeeperRegistryCenter implements RegistryCenter {
     
     @Override
     public String get(final String key) {
-        PathTree cache = findTreeCache(key);
+        final PathTree cache = findTreeCache(key);
         if (null == cache) {
             return getDirectly(key);
         }
@@ -134,7 +134,7 @@ public final class NewZookeeperRegistryCenter implements RegistryCenter {
     @Override
     public List<String> getChildrenKeys(final String key) {
         try {
-            List<String> result = client.getChildren(key);
+            final List<String> result = client.getChildren(key);
             Collections.sort(result, new Comparator<String>() {
                 
                 @Override
@@ -230,9 +230,8 @@ public final class NewZookeeperRegistryCenter implements RegistryCenter {
     }
     
     private void addCacheData(final String cachePath) {
-        PathTree cache = new PathTree(cachePath, client);
+        final PathTree cache = new PathTree(cachePath, client);
         try {
-            // The load() may be no need
             cache.load();
             cache.watch();
         } catch (final KeeperException | InterruptedException ex) {

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/cache/PathTree.java
@@ -231,7 +231,7 @@ public final class PathTree {
             final String value = provider.getDataString(path);
             put(path, value);
         } catch (final KeeperException | InterruptedException ex) {
-            if (ex instanceof KeeperException.NoNodeException) {
+            if (ex instanceof KeeperException.NoNodeException || ex instanceof KeeperException.ConnectionLossException) {
                 log.debug(ex.getMessage());
                 return;
             }

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryCallable.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryCallable.java
@@ -19,25 +19,24 @@ package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
 
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.Connection;
-import lombok.Setter;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.zookeeper.KeeperException;
 
 /*
  * Sync retry call.
- * // todo Split up into two classes, one use exec() and other use getResult()
  *
  * @author lidongbo
  */
 @Slf4j
-public abstract class RetryCallable<T> {
+public abstract class RetryCallable {
     
+    @Getter(value = AccessLevel.PROTECTED)
     private final DelayPolicyExecutor delayPolicyExecutor;
     
+    @Getter(value = AccessLevel.PROTECTED)
     private final IProvider provider;
-    
-    @Setter
-    private T result;
     
     public RetryCallable(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
         this.delayPolicyExecutor = new DelayPolicyExecutor(delayRetryPolicy);
@@ -51,20 +50,6 @@ public abstract class RetryCallable<T> {
      * @throws InterruptedException InterruptedException
      */
     public abstract void call() throws KeeperException, InterruptedException;
-    
-    /**
-     * Get result.
-     *
-     * @return result
-     * @throws KeeperException Zookeeper Exception
-     * @throws InterruptedException InterruptedException
-     */
-    public T getResult() throws KeeperException, InterruptedException {
-        if (result == null) {
-            exec();
-        }
-        return result;
-    }
     
     /**
      * Call without result.

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryResultCallable.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/RetryResultCallable.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.zookeeper.KeeperException;
+
+/*
+ * Sync retry call with Result.
+ *
+ * @author lidongbo
+ */
+@Slf4j
+public abstract class RetryResultCallable<T> extends RetryCallable {
+    
+    @Setter
+    private T result;
+    
+    public RetryResultCallable(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        super(provider, delayRetryPolicy);
+    }
+    
+    /**
+     * Get result.
+     *
+     * @return result
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
+    public T getResult() throws KeeperException, InterruptedException {
+        if (result == null) {
+            exec();
+        }
+        log.debug("result:{}", result);
+        return result;
+    }
+}

--- a/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
+++ b/sharding-jdbc-orchestration/src/main/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/strategy/SyncRetryStrategy.java
@@ -20,6 +20,7 @@ package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.RetryCallable;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.RetryResultCallable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,7 @@ public class SyncRetryStrategy extends UsualStrategy {
 
     @Override
     public byte[] getData(final String key) throws KeeperException, InterruptedException {
-        RetryCallable<byte[]> retryCallable = new RetryCallable<byte[]>(getProvider(), delayRetryPolicy) {
+        RetryResultCallable<byte[]> retryCallable = new RetryResultCallable<byte[]>(getProvider(), delayRetryPolicy) {
             
             @Override
             public void call() throws KeeperException, InterruptedException {
@@ -64,7 +65,7 @@ public class SyncRetryStrategy extends UsualStrategy {
     
     @Override
     public boolean checkExists(final String key) throws KeeperException, InterruptedException {
-        RetryCallable<Boolean> retryCallable = new RetryCallable<Boolean>(getProvider(), delayRetryPolicy) {
+        RetryResultCallable<Boolean> retryCallable = new RetryResultCallable<Boolean>(getProvider(), delayRetryPolicy) {
             
             @Override
             public void call() throws KeeperException, InterruptedException {
@@ -76,7 +77,7 @@ public class SyncRetryStrategy extends UsualStrategy {
     
     @Override
     public boolean checkExists(final String key, final Watcher watcher) throws KeeperException, InterruptedException {
-        RetryCallable<Boolean> retryCallable = new RetryCallable<Boolean>(getProvider(), delayRetryPolicy) {
+        RetryResultCallable<Boolean> retryCallable = new RetryResultCallable<Boolean>(getProvider(), delayRetryPolicy) {
             
             @Override
             public void call() throws KeeperException, InterruptedException {
@@ -88,7 +89,7 @@ public class SyncRetryStrategy extends UsualStrategy {
     
     @Override
     public List<String> getChildren(final String key) throws KeeperException, InterruptedException {
-        RetryCallable<List<String>> retryCallable = new RetryCallable<List<String>>(getProvider(), delayRetryPolicy) {
+        RetryResultCallable<List<String>> retryCallable = new RetryResultCallable<List<String>>(getProvider(), delayRetryPolicy) {
             
             @Override
             public void call() throws KeeperException, InterruptedException {

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestCallable.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestCallable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.provider.BaseProvider;
+import org.apache.zookeeper.KeeperException;
+
+public abstract class TestCallable extends RetryCallable {
+    
+    private int count;
+    
+    public TestCallable(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        super(provider, delayRetryPolicy);
+    }
+    
+    @Override
+    public void call() throws KeeperException, InterruptedException {
+        if (count < 2) {
+            count++;
+            
+            // need dependent zk beat version
+            //((BaseProvider)getProvider()).getHolder().getZooKeeper().getTestable().injectSessionExpiration();
+            ((BaseProvider) getProvider()).getHolder().close();
+        }
+        test();
+    }
+    
+    public abstract void test() throws KeeperException, InterruptedException;
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestCallable.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestCallable.java
@@ -41,5 +41,11 @@ public abstract class TestCallable extends RetryCallable {
         test();
     }
     
+    /**
+     * Test exec.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
     public abstract void test() throws KeeperException, InterruptedException;
 }

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
@@ -21,7 +21,7 @@ import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
 import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.provider.BaseProvider;
 import org.apache.zookeeper.KeeperException;
 
-public abstract class TestResultCallable extends RetryResultCallable {
+public abstract class TestResultCallable<T> extends RetryResultCallable<T> {
     
     private int count;
     

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
@@ -41,5 +41,11 @@ public abstract class TestResultCallable extends RetryResultCallable {
         test();
     }
     
+    /**
+     * Test exec.
+     *
+     * @throws KeeperException Zookeeper Exception
+     * @throws InterruptedException InterruptedException
+     */
     public abstract void test() throws KeeperException, InterruptedException;
 }

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/retry/TestResultCallable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.provider.BaseProvider;
+import org.apache.zookeeper.KeeperException;
+
+public abstract class TestResultCallable extends RetryResultCallable {
+    
+    private int count;
+    
+    public TestResultCallable(final IProvider provider, final DelayRetryPolicy delayRetryPolicy) {
+        super(provider, delayRetryPolicy);
+    }
+    
+    @Override
+    public void call() throws KeeperException, InterruptedException {
+        if (count < 2) {
+            count++;
+
+            // need dependent zk beat version
+            //((BaseProvider)getProvider()).getHolder().getZooKeeper().getTestable().injectSessionExpiration();
+            ((BaseProvider) getProvider()).getHolder().close();
+        }
+        test();
+    }
+    
+    public abstract void test() throws KeeperException, InterruptedException;
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
@@ -123,14 +123,14 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         getTestClient().createAllNeedPath(key, "", CreateMode.PERSISTENT);
         getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
     
-        TestResultCallable callable = new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+        TestResultCallable<Boolean> callable = new TestResultCallable<Boolean>(provider, DelayRetryPolicy.defaultDelayPolicy()) {
             
             @Override
             public void test() throws KeeperException, InterruptedException {
                 setResult(provider.exists(provider.getRealPath(key)));
             }
         };
-        assertTrue(Boolean.valueOf(callable.getResult().toString()));
+        assertTrue(callable.getResult());
     
         getTestClient().useExecStrategy(StrategyType.USUAL);
         getTestClient().deleteCurrentBranch(key);
@@ -144,8 +144,8 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         getTestClient().createAllNeedPath(key, "bbb11", CreateMode.PERSISTENT);
         getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
     
-        TestResultCallable callable = getData("a");
-        assertThat(callable.getResult().toString(), is(""));
+        TestResultCallable<String> callable = getData("a");
+        assertThat(callable.getResult(), is(""));
         callable = getData(key);
         assertThat(callable.getResult().toString(), is("bbb11"));
         
@@ -154,8 +154,8 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
     }
     
-    private TestResultCallable getData(final String key) {
-        return new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+    private TestResultCallable<String> getData(final String key) {
+        return new TestResultCallable<String>(provider, DelayRetryPolicy.defaultDelayPolicy()) {
             
             @Override
             public void test() throws KeeperException, InterruptedException {
@@ -174,14 +174,14 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         getTestClient().createAllNeedPath("a/c", "", CreateMode.PERSISTENT);
         getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
     
-        final TestResultCallable callable = new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+        final TestResultCallable<List<String>> callable = new TestResultCallable<List<String>>(provider, DelayRetryPolicy.defaultDelayPolicy()) {
             
             @Override
             public void test() throws KeeperException, InterruptedException {
                 setResult(provider.getChildren(provider.getRealPath(current)));
             }
         };
-        final List<String> result = (List<String>) callable.getResult();
+        final List<String> result = callable.getResult();
         Collections.sort(result, new Comparator<String>() {
             public int compare(final String o1, final String o2) {
                 return o2.compareTo(o1);

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016-2018 shardingsphere.io.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * </p>
+ */
+
+package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper;
+
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IClient;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.action.IProvider;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.DelayRetryPolicy;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.TestCallable;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.TestResultCallable;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.utility.PathUtil;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base.TestSupport;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.StrategyType;
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.strategy.UsualStrategy;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class SyncRetryStrategyTest extends UsualClientTest {
+    
+    private IProvider provider;
+    
+    @Override
+    protected IClient createClient(final ClientFactory creator) throws IOException, InterruptedException {
+        final IClient client = creator.setClientNamespace(TestSupport.ROOT).authorization(TestSupport.AUTH, TestSupport.AUTH.getBytes(), ZooDefs.Ids.CREATOR_ALL_ACL)
+                .newClient(TestSupport.SERVERS, TestSupport.SESSION_TIMEOUT).watch(TestSupport.buildListener()).start();
+        client.useExecStrategy(StrategyType.SYNC_RETRY);
+        provider = ((UsualClient) client).getStrategy().getProvider();
+        return client;
+    }
+    
+    @Test
+    public void createChild() throws KeeperException, InterruptedException {
+        final String key = "a/b/bb";
+        new UsualStrategy(provider).deleteCurrentBranch(key);
+        TestCallable callable = new TestCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                getTestClient().useExecStrategy(StrategyType.USUAL);
+                getTestClient().createAllNeedPath(key, "bbb11", CreateMode.PERSISTENT);
+                getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+            }
+        };
+        callable.exec();
+        
+        assertTrue(getTestClient().checkExists(key));
+        new UsualStrategy(provider).deleteCurrentBranch(key);
+        assertFalse(getTestClient().checkExists(key));
+    }
+    
+    @Test
+    public void deleteBranch() throws KeeperException, InterruptedException {
+        final String keyB = "a/b/bb";
+        final String value = "bbb11";
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().createAllNeedPath(keyB, value, CreateMode.PERSISTENT);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    
+        assertTrue(getTestClient().checkExists(keyB));
+        final String keyC = "a/c/cc";
+        new UsualStrategy(provider).createAllNeedPath(keyC, "ccc11", CreateMode.PERSISTENT);
+        assertTrue(getTestClient().checkExists(keyC));
+        
+        TestCallable callable = getDeleteBranch(keyC);
+        callable.exec();
+    
+        assertFalse(getTestClient().checkExists(keyC));
+        assertTrue(getTestClient().checkExists("a"));
+    
+        callable = getDeleteBranch(keyB);
+        callable.exec();
+    
+        assertFalse(getTestClient().checkExists(PathUtil.checkPath(TestSupport.ROOT)));
+        getTestClient().createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
+        assertTrue(getTestClient().checkExists(keyB));
+        
+        callable.exec();
+    
+        assertFalse(getTestClient().checkExists(PathUtil.checkPath(TestSupport.ROOT)));
+    }
+    
+    private TestCallable getDeleteBranch(final String key) {
+        return new TestCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                getTestClient().useExecStrategy(StrategyType.USUAL);
+                getTestClient().deleteCurrentBranch(key);
+                getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+            }
+        };
+    }
+    
+    @Test
+    public void isExisted() throws KeeperException, InterruptedException {
+        final String key = "a/b/bb";
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().createAllNeedPath(key, "", CreateMode.PERSISTENT);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    
+        TestResultCallable callable = new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                setResult(provider.exists(provider.getRealPath(key)));
+            }
+        };
+
+        assertTrue(Boolean.valueOf(callable.getResult().toString()));
+    
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().deleteCurrentBranch(key);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    }
+    
+    @Test
+    public void get() throws KeeperException, InterruptedException {
+        final String key = "a/b";
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().createAllNeedPath(key, "bbb11", CreateMode.PERSISTENT);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    
+        TestResultCallable callable = getData("a");
+        assertThat(callable.getResult().toString(), is(""));
+        callable = getData(key);
+        assertThat(callable.getResult().toString(), is("bbb11"));
+        
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().deleteCurrentBranch(key);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    }
+    
+    private TestResultCallable getData(final String key) {
+        return new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                setResult(new String(provider.getData(provider.getRealPath(key))));
+            }
+        };
+    }
+    
+    @Test
+    public void getChildrenKeys() throws KeeperException, InterruptedException {
+        final String key = "a/b";
+        final String current = "a";
+        
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().createAllNeedPath(key, "", CreateMode.PERSISTENT);
+        getTestClient().createAllNeedPath("a/c", "", CreateMode.PERSISTENT);
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    
+        final TestResultCallable callable = new TestResultCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                setResult(provider.getChildren(provider.getRealPath(current)));
+            }
+        };
+        final List<String> result = (List<String>) callable.getResult();
+        Collections.sort(result, new Comparator<String>() {
+            public int compare(final String o1, final String o2) {
+                return o2.compareTo(o1);
+            }
+        });
+        assertThat(result.get(0), is("c"));
+        assertThat(result.get(1), is("b"));
+        
+        getTestClient().useExecStrategy(StrategyType.USUAL);
+        getTestClient().deleteAllChildren(PathUtil.checkPath(TestSupport.ROOT));
+        getTestClient().useExecStrategy(StrategyType.SYNC_RETRY);
+    }
+    
+    @Test
+    public void update() throws KeeperException, InterruptedException {
+        final String key = "a";
+        final String value = "aa";
+        final String newValue = "aaa";
+//        getTestClient().deleteCurrentBranch(key);
+        getTestClient().createAllNeedPath(key, value, CreateMode.PERSISTENT);
+        assertThat(getTestClient().getDataString(key), is(value));
+    
+        final TestCallable callable = new TestCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                provider.update(provider.getRealPath(key), newValue);
+            }
+        };
+        callable.exec();
+    
+        assertThat(getTestClient().getDataString(key), is(newValue));
+        getTestClient().deleteCurrentBranch(key);
+    }
+    
+    @Test
+    public void delAllChildren() throws KeeperException, InterruptedException {
+        String key = "a/b/bb";
+        getTestClient().createAllNeedPath(key, "bb", CreateMode.PERSISTENT);
+        key = "a/c/cc";
+        getTestClient().createAllNeedPath(key, "cc", CreateMode.PERSISTENT);
+        log.debug("nearest children count:{}", getZooKeeper(getTestClient()).exists(PathUtil.getRealPath(TestSupport.ROOT, "a"), null).getNumChildren());
+        assertNotNull(getZooKeeper(getTestClient()).exists(PathUtil.getRealPath(TestSupport.ROOT, key), false));
+    
+        TestCallable callable = new TestCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            @Override
+            public void test() throws KeeperException, InterruptedException {
+                new UsualStrategy(provider).deleteAllChildren("a");
+            }
+        };
+        callable.exec();
+    
+        assertNull(getZooKeeper(getTestClient()).exists(PathUtil.getRealPath(TestSupport.ROOT, key), false));
+        assertNotNull(getZooKeeper(getTestClient()).exists(PathUtil.checkPath(TestSupport.ROOT), false));
+        super.deleteRoot(getTestClient());
+    }
+}

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
@@ -71,7 +71,6 @@ public class SyncRetryStrategyTest extends UsualClientTest {
             }
         };
         callable.exec();
-        
         assertTrue(getTestClient().checkExists(key));
         new UsualStrategy(provider).deleteCurrentBranch(key);
         assertFalse(getTestClient().checkExists(key));
@@ -92,24 +91,22 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         
         TestCallable callable = getDeleteBranch(keyC);
         callable.exec();
-    
         assertFalse(getTestClient().checkExists(keyC));
         assertTrue(getTestClient().checkExists("a"));
     
         callable = getDeleteBranch(keyB);
         callable.exec();
-    
         assertFalse(getTestClient().checkExists(PathUtil.checkPath(TestSupport.ROOT)));
         getTestClient().createAllNeedPath(keyB, "bbb11", CreateMode.PERSISTENT);
         assertTrue(getTestClient().checkExists(keyB));
         
         callable.exec();
-    
         assertFalse(getTestClient().checkExists(PathUtil.checkPath(TestSupport.ROOT)));
     }
     
     private TestCallable getDeleteBranch(final String key) {
         return new TestCallable(provider, DelayRetryPolicy.defaultDelayPolicy()) {
+            
             @Override
             public void test() throws KeeperException, InterruptedException {
                 getTestClient().useExecStrategy(StrategyType.USUAL);
@@ -133,7 +130,6 @@ public class SyncRetryStrategyTest extends UsualClientTest {
                 setResult(provider.exists(provider.getRealPath(key)));
             }
         };
-
         assertTrue(Boolean.valueOf(callable.getResult().toString()));
     
         getTestClient().useExecStrategy(StrategyType.USUAL);
@@ -204,7 +200,7 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         final String key = "a";
         final String value = "aa";
         final String newValue = "aaa";
-//        getTestClient().deleteCurrentBranch(key);
+        getTestClient().deleteCurrentBranch(key);
         getTestClient().createAllNeedPath(key, value, CreateMode.PERSISTENT);
         assertThat(getTestClient().getDataString(key), is(value));
     
@@ -216,7 +212,6 @@ public class SyncRetryStrategyTest extends UsualClientTest {
             }
         };
         callable.exec();
-    
         assertThat(getTestClient().getDataString(key), is(newValue));
         getTestClient().deleteCurrentBranch(key);
     }
@@ -237,7 +232,6 @@ public class SyncRetryStrategyTest extends UsualClientTest {
             }
         };
         callable.exec();
-    
         assertNull(getZooKeeper(getTestClient()).exists(PathUtil.getRealPath(TestSupport.ROOT, key), false));
         assertNotNull(getZooKeeper(getTestClient()).exists(PathUtil.checkPath(TestSupport.ROOT), false));
         super.deleteRoot(getTestClient());

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/SyncRetryStrategyTest.java
@@ -147,7 +147,7 @@ public class SyncRetryStrategyTest extends UsualClientTest {
         TestResultCallable<String> callable = getData("a");
         assertThat(callable.getResult(), is(""));
         callable = getData(key);
-        assertThat(callable.getResult().toString(), is("bbb11"));
+        assertThat(callable.getResult(), is("bbb11"));
         
         getTestClient().useExecStrategy(StrategyType.USUAL);
         getTestClient().deleteCurrentBranch(key);

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseClientTest.java
@@ -65,7 +65,7 @@ public abstract class BaseClientTest extends BaseTest {
         getZooKeeper(testClient);
     }
     
-    private ZooKeeper getZooKeeper(final IClient client) {
+    protected ZooKeeper getZooKeeper(final IClient client) {
         return ((BaseClient) client).getHolder().getZooKeeper();
     }
     

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseTest.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/BaseTest.java
@@ -33,8 +33,7 @@ public class BaseTest {
     protected void sleep(final long tick) {
         try {
             Thread.sleep(tick);
-        } catch (final InterruptedException ex) {
-            // ignore
+        } catch (final InterruptedException ignore) {
         }
     }
 }

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
@@ -42,9 +42,7 @@ public class TestSupport {
             
             @Override
             public void process(final WatchedEvent event) {
-                log.debug("==========================================================");
                 log.debug(event.toString());
-                log.debug("==========================================================");
             }
         };
     }

--- a/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
+++ b/sharding-jdbc-orchestration/src/test/java/io/shardingsphere/jdbc/orchestration/reg/newzk/client/zookeeper/base/TestSupport.java
@@ -17,6 +17,11 @@
 
 package io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.base;
 
+import io.shardingsphere.jdbc.orchestration.reg.newzk.client.zookeeper.section.ZookeeperEventListener;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.zookeeper.WatchedEvent;
+
+@Slf4j
 public class TestSupport {
     
     public static final String AUTH = "digest";
@@ -26,4 +31,21 @@ public class TestSupport {
     public static final int SESSION_TIMEOUT = 200000;
     
     public static final String ROOT = "test";
+    
+    /**
+     * Test exec.
+     *
+     * @return listener ZookeeperEventListener
+     */
+    public static ZookeeperEventListener buildListener() {
+        return new ZookeeperEventListener() {
+            
+            @Override
+            public void process(final WatchedEvent event) {
+                log.debug("==========================================================");
+                log.debug(event.toString());
+                log.debug("==========================================================");
+            }
+        };
+    }
 }

--- a/sharding-jdbc-orchestration/src/test/resources/logback-test.xml
+++ b/sharding-jdbc-orchestration/src/test/resources/logback-test.xml
@@ -8,6 +8,9 @@
     <logger name="io.shardingsphere" level="warn" additivity="false">
         <appender-ref ref="console"/>
     </logger>
+    <logger name="io.shardingsphere.jdbc.orchestration.reg.newzk.client.retry.RetryCallable" level="error" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
     <root>
         <level value="error" />
         <appender-ref ref="console" />


### PR DESCRIPTION
Fixes a todo

Changes proposed in this pull request:
-todo Split up into two classes, one use exec() and other use getResult()
-sync retry strategy unit test
-
