### PR TITLE
Use same worker thread group to handle IO event for  frontend and backend.

### DIFF
--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/Bootstrap.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/Bootstrap.java
@@ -89,7 +89,7 @@ public final class Bootstrap {
                                                    final Map<String, Object> configMap, final Properties prop, final int port) throws InterruptedException {
         GlobalRegistry.getInstance().init(getDataSourceParameterMap(ruleConfigs), getRuleConfiguration(ruleConfigs), authentication, configMap, prop);
         initOpenTracing();
-        new ShardingProxy().start(port);
+        ShardingProxy.getInstance().start(port);
     }
     
     private static void startWithRegistryCenter(final YamlProxyServerConfiguration serverConfig,
@@ -97,10 +97,10 @@ public final class Bootstrap {
         try (ShardingOrchestrationFacade shardingOrchestrationFacade = new ShardingOrchestrationFacade(serverConfig.getOrchestration().getOrchestrationConfiguration(), shardingSchemaNames)) {
             initShardingOrchestrationFacade(serverConfig, ruleConfigs, shardingOrchestrationFacade);
             GlobalRegistry.getInstance().init(getSchemaDataSourceParameterMap(shardingOrchestrationFacade), getSchemaRules(shardingOrchestrationFacade),
-                    shardingOrchestrationFacade.getConfigService().loadAuthentication(), shardingOrchestrationFacade.getConfigService().loadConfigMap(), 
+                    shardingOrchestrationFacade.getConfigService().loadAuthentication(), shardingOrchestrationFacade.getConfigService().loadConfigMap(),
                     shardingOrchestrationFacade.getConfigService().loadProperties(), true);
             initOpenTracing();
-            new ShardingProxy().start(port);
+            ShardingProxy.getInstance().start(port);
         }
     }
     

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/netty/client/BackendNettyClientManager.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/backend/netty/client/BackendNettyClientManager.java
@@ -17,6 +17,7 @@
 
 package io.shardingsphere.shardingproxy.backend.netty.client;
 
+import io.netty.channel.EventLoopGroup;
 import io.shardingsphere.shardingproxy.runtime.GlobalRegistry;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -60,11 +61,12 @@ public final class BackendNettyClientManager {
     /**
      * Start all backend connection client for netty.
      *
+     * @param eventLoopGroup Worker thread group of IO is used for frontend connecting with client and backend connecting with DB.
      * @throws InterruptedException interrupted exception
      */
-    public void start() throws InterruptedException {
+    public void start(final EventLoopGroup eventLoopGroup) throws InterruptedException {
         for (String each : GLOBAL_REGISTRY.getSchemaNames()) {
-            BackendNettyClient backendNettyClient = new BackendNettyClient(GLOBAL_REGISTRY.getLogicSchema(each));
+            BackendNettyClient backendNettyClient = new BackendNettyClient(GLOBAL_REGISTRY.getLogicSchema(each), eventLoopGroup);
             clientMap.put(each, backendNettyClient);
             backendNettyClient.start();
         }

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/FrontendHandlerFactory.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/FrontendHandlerFactory.java
@@ -17,7 +17,6 @@
 
 package io.shardingsphere.shardingproxy.frontend.common;
 
-import io.netty.channel.EventLoopGroup;
 import io.shardingsphere.core.constant.DatabaseType;
 import io.shardingsphere.shardingproxy.frontend.mysql.MySQLFrontendHandler;
 import lombok.AccessLevel;
@@ -36,13 +35,12 @@ public final class FrontendHandlerFactory {
      * Create frontend handler instance.
      *
      * @param databaseType database type
-     * @param userGroup user group
      * @return frontend handler instance
      */
-    public static FrontendHandler createFrontendHandlerInstance(final DatabaseType databaseType, final EventLoopGroup userGroup) {
+    public static FrontendHandler createFrontendHandlerInstance(final DatabaseType databaseType) {
         switch (databaseType) {
             case MySQL:
-                return new MySQLFrontendHandler(userGroup);
+                return new MySQLFrontendHandler();
             default:
                 throw new UnsupportedOperationException(String.format("Cannot support database type '%s'", databaseType));
         }

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/executor/ExecutorGroup.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/executor/ExecutorGroup.java
@@ -18,8 +18,8 @@
 package io.shardingsphere.shardingproxy.frontend.common.executor;
 
 import io.netty.channel.ChannelId;
-import io.netty.channel.EventLoopGroup;
 import io.shardingsphere.core.constant.transaction.TransactionType;
+import io.shardingsphere.shardingproxy.frontend.ShardingProxy;
 import io.shardingsphere.shardingproxy.runtime.GlobalRegistry;
 import lombok.RequiredArgsConstructor;
 
@@ -35,8 +35,6 @@ public final class ExecutorGroup {
     
     private static final GlobalRegistry GLOBAL_REGISTRY = GlobalRegistry.getInstance();
     
-    private final EventLoopGroup eventLoopGroup;
-    
     private final ChannelId channelId;
     
     /**
@@ -45,6 +43,6 @@ public final class ExecutorGroup {
      * @return executor service
      */
     public ExecutorService getExecutorService() {
-        return TransactionType.XA == GLOBAL_REGISTRY.getTransactionType() ? ChannelThreadExecutorGroup.getInstance().get(channelId) : eventLoopGroup;
+        return TransactionType.XA == GLOBAL_REGISTRY.getTransactionType() ? ChannelThreadExecutorGroup.getInstance().get(channelId) : ShardingProxy.getInstance().getCommandExecutorService();
     }
 }

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/netty/ServerHandlerInitializer.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/common/netty/ServerHandlerInitializer.java
@@ -19,7 +19,6 @@ package io.shardingsphere.shardingproxy.frontend.common.netty;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.shardingsphere.core.constant.DatabaseType;
 import io.shardingsphere.shardingproxy.frontend.common.FrontendHandlerFactory;
@@ -34,13 +33,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public final class ServerHandlerInitializer extends ChannelInitializer<SocketChannel> {
     
-    private final EventLoopGroup userGroup;
-    
     @Override
     protected void initChannel(final SocketChannel socketChannel) {
         ChannelPipeline pipeline = socketChannel.pipeline();
         // TODO load database type from yaml or startup arguments
         pipeline.addLast(PacketCodecFactory.newInstance(DatabaseType.MySQL));
-        pipeline.addLast(FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.MySQL, userGroup));
+        pipeline.addLast(FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.MySQL));
     }
 }

--- a/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/mysql/MySQLFrontendHandler.java
+++ b/sharding-proxy/src/main/java/io/shardingsphere/shardingproxy/frontend/mysql/MySQLFrontendHandler.java
@@ -20,7 +20,6 @@ package io.shardingsphere.shardingproxy.frontend.mysql;
 import com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoopGroup;
 import io.shardingsphere.shardingproxy.frontend.common.FrontendHandler;
 import io.shardingsphere.shardingproxy.frontend.common.executor.ExecutorGroup;
 import io.shardingsphere.shardingproxy.runtime.ChannelRegistry;
@@ -45,8 +44,6 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 public final class MySQLFrontendHandler extends FrontendHandler {
-    
-    private final EventLoopGroup eventLoopGroup;
     
     private final AuthenticationHandler authenticationHandler = new AuthenticationHandler();
     
@@ -79,7 +76,7 @@ public final class MySQLFrontendHandler extends FrontendHandler {
     
     @Override
     protected void executeCommand(final ChannelHandlerContext context, final ByteBuf message) {
-        new ExecutorGroup(eventLoopGroup, context.channel().id()).getExecutorService().execute(new CommandExecutor(context, message, this));
+        new ExecutorGroup(context.channel().id()).getExecutorService().execute(new CommandExecutor(context, message, this));
     }
     
     @Override

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/frontend/common/FrontendHandlerFactoryTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/frontend/common/FrontendHandlerFactoryTest.java
@@ -43,11 +43,11 @@ public final class FrontendHandlerFactoryTest {
     
     @Test
     public void assertCreateFrontendHandlerInstanceWithMySQL() {
-        assertThat(FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.MySQL, null), instanceOf(MySQLFrontendHandler.class));
+        assertThat(FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.MySQL), instanceOf(MySQLFrontendHandler.class));
     }
     
     @Test(expected = UnsupportedOperationException.class)
     public void assertCreateFrontendHandlerInstanceWhenUnsupported() {
-        FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.Oracle, null);
+        FrontendHandlerFactory.createFrontendHandlerInstance(DatabaseType.Oracle);
     }
 }

--- a/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/frontend/mysql/MySQLFrontendHandlerTest.java
+++ b/sharding-proxy/src/test/java/io/shardingsphere/shardingproxy/frontend/mysql/MySQLFrontendHandlerTest.java
@@ -21,11 +21,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
-import io.netty.channel.EventLoopGroup;
 import io.shardingsphere.core.constant.properties.ShardingProperties;
 import io.shardingsphere.core.constant.properties.ShardingPropertiesConstant;
 import io.shardingsphere.core.constant.transaction.TransactionType;
 import io.shardingsphere.core.rule.Authentication;
+import io.shardingsphere.shardingproxy.frontend.ShardingProxy;
 import io.shardingsphere.shardingproxy.runtime.GlobalRegistry;
 import io.shardingsphere.shardingproxy.transport.mysql.packet.generic.ErrPacket;
 import io.shardingsphere.shardingproxy.transport.mysql.packet.generic.OKPacket;
@@ -41,6 +41,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Field;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
 
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -53,7 +54,7 @@ public final class MySQLFrontendHandlerTest {
     private MySQLFrontendHandler mysqlFrontendHandler;
     
     @Mock
-    private EventLoopGroup eventLoopGroup;
+    private ExecutorService executorService;
     
     @Mock
     private ChannelHandlerContext context;
@@ -72,7 +73,7 @@ public final class MySQLFrontendHandlerTest {
         Field field = ConnectionIdGenerator.class.getDeclaredField("currentId");
         field.setAccessible(true);
         field.set(ConnectionIdGenerator.getInstance(), 0);
-        mysqlFrontendHandler = new MySQLFrontendHandler(eventLoopGroup);
+        mysqlFrontendHandler = new MySQLFrontendHandler();
     }
     
     @Test
@@ -113,7 +114,14 @@ public final class MySQLFrontendHandlerTest {
         when(channel.id()).thenReturn(channelId);
         when(context.channel()).thenReturn(channel);
         setTransactionType();
+        setShardingProxyCommandExecutorService(executorService);
         mysqlFrontendHandler.executeCommand(context, mock(ByteBuf.class));
+    }
+    
+    private void setShardingProxyCommandExecutorService(final ExecutorService commandExecutorService) throws ReflectiveOperationException {
+        Field field = ShardingProxy.getInstance().getClass().getDeclaredField("commandExecutorService");
+        field.setAccessible(true);
+        field.set(ShardingProxy.getInstance(), commandExecutorService);
     }
     
     private void setAuthentication(final Object value) throws ReflectiveOperationException {


### PR DESCRIPTION
1. Use same worker thread group for frontend connecting with client and backend connecting with DB.

2. Replace userGroup(class is EventLoopGroup) with commandExecutorService (class is ExecutorService), because EventLoopGroup belongs to Netty, but CommandExecutor only runs in a thread pool, CommandExecutor has no relation with Netty.