### PR TITLE
sharding config changes from v3.0.0 to v3.1.0

### DIFF
--- a/sharding-core/src/main/antlr4/imports/BaseRule.g4
+++ b/sharding-core/src/main/antlr4/imports/BaseRule.g4
@@ -179,7 +179,7 @@ domainNames
     : domainName (COMMA domainName)*
     ;
     
-tableNamesWithParen
+tableList
     : LP_ tableNames RP_
     ;
     

--- a/sharding-core/src/main/antlr4/imports/MySQLBase.g4
+++ b/sharding-core/src/main/antlr4/imports/MySQLBase.g4
@@ -6,6 +6,10 @@ alias
     : ID | PASSWORD | STRING
     ;
     
+tableName
+    : ID | ID DOT_ASTERISK | ASTERISK
+    ;
+    
 characterSet
     : (CHARACTER | CHAR) SET EQ_? charsetName | CHARSET EQ_? charsetName
     ;

--- a/sharding-core/src/main/antlr4/imports/MySQLDCLStatement.g4
+++ b/sharding-core/src/main/antlr4/imports/MySQLDCLStatement.g4
@@ -1,6 +1,6 @@
 grammar MySQLDCLStatement;
 
-import MySQLKeyword, Keyword, BaseRule, DataType, Symbol;
+import MySQLKeyword, Keyword, MySQLBase, BaseRule, DataType, Symbol;
 
 grant
     : GRANT privType columnList? (COMMA privType columnList?)*
@@ -60,10 +60,7 @@ objectType
     ;
     
 privLevel
-    : ASTERISK
-    | ASTERISK DOT_ASTERISK
-    | schemaName DOT_ASTERISK
-    | schemaName DOT tableName
+    : ASTERISK DOT_ASTERISK
     | tableName
     | schemaName DOT routineName
     ;

--- a/sharding-core/src/main/antlr4/imports/MySQLTableBase.g4
+++ b/sharding-core/src/main/antlr4/imports/MySQLTableBase.g4
@@ -103,7 +103,7 @@ tableOption
     | STATS_PERSISTENT EQ_? (DEFAULT | NUMBER)
     | STATS_SAMPLE_PAGES EQ_? NUMBER
     | TABLESPACE tablespaceName (STORAGE (DISK | MEMORY | DEFAULT))?
-    | UNION EQ_? tableNamesWithParen
+    | UNION EQ_? tableList
     ;
     
 engineName

--- a/sharding-core/src/main/antlr4/imports/OracleDCLStatement.g4
+++ b/sharding-core/src/main/antlr4/imports/OracleDCLStatement.g4
@@ -50,9 +50,9 @@ objectPrivilege
 onObjectClause
     : ON 
     (
-        schemaName? ID 
+       tableName 
        | USER userName ( COMMA userName)*
-       | (DIRECTORY | EDITION | MINING MODEL | JAVA (SOURCE | RESOURCE) | SQL TRANSLATION PROFILE) schemaName? ID 
+       | (DIRECTORY | EDITION | MINING MODEL | JAVA (SOURCE | RESOURCE) | SQL TRANSLATION PROFILE) tableName 
     )
     ;
     
@@ -65,7 +65,7 @@ programUnits
     ;
     
 programUnit
-    : (FUNCTION | PROCEDURE | PACKAGE) schemaName? ID
+    : (FUNCTION | PROCEDURE | PACKAGE) tableName
     ;
     
 revoke
@@ -133,7 +133,7 @@ containerDataClause
           SET CONTAINER_DATA EQ_ ( ALL | DEFAULT | idList )
           | (ADD |REMOVE) CONTAINER_DATA EQ_ idList
     )
-    (FOR schemaName? ID)?
+    (FOR tableName)?
     ;
     
 proxyClause
@@ -153,14 +153,14 @@ createRole
     : CREATE ROLE roleName
     ( 
         NOT IDENTIFIED
-        | IDENTIFIED (BY ID | USING schemaName? ID | EXTERNALLY | GLOBALLY)
+        | IDENTIFIED (BY ID | USING tableName | EXTERNALLY | GLOBALLY)
     )? 
     (CONTAINER EQ_ (CURRENT | ALL))? 
     ;
     
 alterRole
     : ALTER ROLE roleName
-    (NOT IDENTIFIED | IDENTIFIED (BY ID | USING schemaName? ID | EXTERNALLY | GLOBALLY))
+    (NOT IDENTIFIED | IDENTIFIED (BY ID | USING tableName | EXTERNALLY | GLOBALLY))
     (CONTAINER EQ_ (CURRENT | ALL))? 
     ;
     

--- a/sharding-core/src/main/antlr4/imports/SQLServerAlterTable.g4
+++ b/sharding-core/src/main/antlr4/imports/SQLServerAlterTable.g4
@@ -85,7 +85,7 @@ alterDrop
     (
         alterTableDropConstraint
         | dropColumn
-        | alterDropIndex
+        | dropIndexDef
         | PERIOD FOR SYSTEM_TIME
     )
     ;
@@ -114,7 +114,7 @@ dropColumn
     : COLUMN (IF EXISTS)? columnNames
     ;
     
-alterDropIndex
+dropIndexDef
     : INDEX (IF EXISTS)? indexName (COMMA indexName)*
     ;
     

--- a/sharding-core/src/main/antlr4/imports/SQLServerDCLStatement.g4
+++ b/sharding-core/src/main/antlr4/imports/SQLServerDCLStatement.g4
@@ -11,7 +11,7 @@ grantGeneral
     ;
     
 generalPrisOn
-    : (ALL PRIVILEGES? | permissionOnColumns (COMMA permissionOnColumns)*) (ON (ID COLON COLON)? ID)?
+    : (ALL PRIVILEGES? | permissionOnColumns (COMMA permissionOnColumns)*) (ON (ID COLON COLON)? tableName)?
     ;
     
 permissionOnColumns
@@ -45,7 +45,7 @@ revokeDW
     ;
     
 permissionWithClass
-    : permission (COMMA permission)* (ON (classType COLON COLON)? ID)?
+    : permission (COMMA permission)* (ON (classType COLON COLON)? tableName)?
     ;
     
 deny

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/AddColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/AddColumnExtractor.java
@@ -23,7 +23,6 @@ import io.shardingsphere.core.parsing.antlr.extractor.util.ExtractorUtils;
 import io.shardingsphere.core.parsing.antlr.extractor.util.RuleName;
 import io.shardingsphere.core.parsing.antlr.sql.segment.column.ColumnDefinitionSegment;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -59,6 +58,6 @@ public class AddColumnExtractor implements CollectionSQLSegmentExtractor {
         return result;
     }
     
-    protected void postExtractColumnDefinition(final ParseTree ancestorNode, final ColumnDefinitionSegment columnDefinitionSegment) {
+    protected void postExtractColumnDefinition(final ParserRuleContext addColumnNode, final ColumnDefinitionSegment columnDefinitionSegment) {
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/DropColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/DropColumnExtractor.java
@@ -17,8 +17,7 @@
 
 package io.shardingsphere.core.parsing.antlr.extractor.impl;
 
-import com.google.common.base.Optional;
-import io.shardingsphere.core.parsing.antlr.extractor.OptionalSQLSegmentExtractor;
+import io.shardingsphere.core.parsing.antlr.extractor.CollectionSQLSegmentExtractor;
 import io.shardingsphere.core.parsing.antlr.extractor.util.ExtractorUtils;
 import io.shardingsphere.core.parsing.antlr.extractor.util.RuleName;
 import io.shardingsphere.core.parsing.antlr.sql.segment.column.DropColumnSegment;
@@ -27,26 +26,29 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 /**
  * Drop column extractor.
  *
  * @author duhongjun
  */
-public final class DropColumnExtractor implements OptionalSQLSegmentExtractor {
+public final class DropColumnExtractor implements CollectionSQLSegmentExtractor {
     
     @Override
-    public Optional<DropColumnSegment> extract(final ParserRuleContext ancestorNode) {
-        Collection<ParserRuleContext> dropColumnNodes = ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.DROP_COLUMN);
-        if (dropColumnNodes.isEmpty()) {
-            return Optional.absent();
+    public Collection<DropColumnSegment> extract(final ParserRuleContext ancestorNode) {
+        Collection<DropColumnSegment> result = new HashSet<>();
+        for (ParserRuleContext each : ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.DROP_COLUMN)) {
+            result.addAll(extractDropColumnSegments(each));
         }
-        DropColumnSegment result = new DropColumnSegment();
-        for (ParserRuleContext each : dropColumnNodes) {
-            for (ParseTree columnNode : ExtractorUtils.getAllDescendantNodes(each, RuleName.COLUMN_NAME)) {
-                result.getDropColumnNames().add(SQLUtil.getExactlyValue(columnNode.getText()));
-            }
+        return result;
+    }
+    
+    private Collection<DropColumnSegment> extractDropColumnSegments(final ParserRuleContext dropColumnNode) {
+        Collection<DropColumnSegment> result = new HashSet<>();
+        for (ParseTree each : ExtractorUtils.getAllDescendantNodes(dropColumnNode, RuleName.COLUMN_NAME)) {
+            result.add(new DropColumnSegment(SQLUtil.getExactlyValue(each.getText())));
         }
-        return Optional.of(result);
+        return result;
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/ModifyColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/ModifyColumnExtractor.java
@@ -25,7 +25,6 @@ import io.shardingsphere.core.parsing.antlr.sql.segment.column.ColumnDefinitionS
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -35,25 +34,21 @@ import java.util.LinkedList;
  */
 public class ModifyColumnExtractor implements CollectionSQLSegmentExtractor {
     
-    private final ColumnDefinitionExtractor columnDefinitionPhraseExtractor = new ColumnDefinitionExtractor();
+    private final ColumnDefinitionExtractor columnDefinitionExtractor = new ColumnDefinitionExtractor();
     
     @Override
     public final Collection<ColumnDefinitionSegment> extract(final ParserRuleContext ancestorNode) {
-        Collection<ParserRuleContext> modifyColumnNodes = ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.MODIFY_COLUMN);
-        if (modifyColumnNodes.isEmpty()) {
-            return Collections.emptyList();
-        }
         Collection<ColumnDefinitionSegment> result = new LinkedList<>();
-        for (ParserRuleContext each : modifyColumnNodes) {
-            Optional<ColumnDefinitionSegment> columnDefinition = columnDefinitionPhraseExtractor.extract(each);
-            if (columnDefinition.isPresent()) {
-                postExtractColumnDefinition(each, columnDefinition.get());
-                result.add(columnDefinition.get());
+        for (ParserRuleContext each : ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.MODIFY_COLUMN)) {
+            Optional<ColumnDefinitionSegment> columnDefinitionSegment = columnDefinitionExtractor.extract(each);
+            if (columnDefinitionSegment.isPresent()) {
+                postExtractColumnDefinition(each, columnDefinitionSegment.get());
+                result.add(columnDefinitionSegment.get());
             }
         }
         return result;
     }
     
-    protected void postExtractColumnDefinition(final ParserRuleContext ancestorNode, final ColumnDefinitionSegment columnDefinition) {
+    protected void postExtractColumnDefinition(final ParserRuleContext modifyColumnNode, final ColumnDefinitionSegment columnDefinition) {
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLAddColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLAddColumnExtractor.java
@@ -22,7 +22,6 @@ import io.shardingsphere.core.parsing.antlr.extractor.impl.AddColumnExtractor;
 import io.shardingsphere.core.parsing.antlr.sql.segment.column.ColumnDefinitionSegment;
 import io.shardingsphere.core.parsing.antlr.sql.segment.column.ColumnPositionSegment;
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ParseTree;
 
 /**
  * Add column extractor for MySQL.
@@ -32,10 +31,10 @@ import org.antlr.v4.runtime.tree.ParseTree;
 public final class MySQLAddColumnExtractor extends AddColumnExtractor {
     
     @Override
-    protected void postExtractColumnDefinition(final ParseTree ancestorNode, final ColumnDefinitionSegment columnDefinitionSegment) {
-        Optional<ColumnPositionSegment> columnPosition = new MySQLColumnPositionExtractor(columnDefinitionSegment.getName()).extract((ParserRuleContext) ancestorNode);
-        if (columnPosition.isPresent()) {
-            columnDefinitionSegment.setPosition(columnPosition.get());
+    protected void postExtractColumnDefinition(final ParserRuleContext addColumnNode, final ColumnDefinitionSegment columnDefinitionSegment) {
+        Optional<ColumnPositionSegment> columnPositionSegment = new MySQLColumnPositionExtractor(columnDefinitionSegment.getName()).extract(addColumnNode);
+        if (columnPositionSegment.isPresent()) {
+            columnDefinitionSegment.setPosition(columnPositionSegment.get());
         }
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLAddIndexExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLAddIndexExtractor.java
@@ -17,15 +17,16 @@
 
 package io.shardingsphere.core.parsing.antlr.extractor.impl.dialect.mysql;
 
+import com.google.common.base.Optional;
 import io.shardingsphere.core.parsing.antlr.extractor.CollectionSQLSegmentExtractor;
-import io.shardingsphere.core.parsing.antlr.extractor.impl.IndexNamesExtractor;
+import io.shardingsphere.core.parsing.antlr.extractor.impl.IndexNameExtractor;
 import io.shardingsphere.core.parsing.antlr.extractor.util.ExtractorUtils;
 import io.shardingsphere.core.parsing.antlr.extractor.util.RuleName;
 import io.shardingsphere.core.parsing.antlr.sql.segment.IndexSegment;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedList;
 
 /**
  * Add index extractor for MySQL.
@@ -34,15 +35,18 @@ import java.util.Collections;
  */
 public final class MySQLAddIndexExtractor implements CollectionSQLSegmentExtractor {
     
-    private final IndexNamesExtractor indexesNameExtractor = new IndexNamesExtractor();
+    private final IndexNameExtractor indexNameExtractor = new IndexNameExtractor();
     
     @Override
     public Collection<IndexSegment> extract(final ParserRuleContext ancestorNode) {
+        Collection<IndexSegment> result = new LinkedList<>();
         Collection<ParserRuleContext> addIndexNodes = ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.ADD_INDEX);
-        if (addIndexNodes.isEmpty()) {
-            return Collections.emptyList();
+        for (ParserRuleContext each : addIndexNodes) {
+            Optional<IndexSegment> indexSegment = indexNameExtractor.extract(each);
+            if (indexSegment.isPresent()) {
+                result.add(indexSegment.get());
+            }
         }
-       
-        return indexesNameExtractor.extract(ancestorNode);
+        return result;
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLChangeColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLChangeColumnExtractor.java
@@ -33,7 +33,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
  */
 public final class MySQLChangeColumnExtractor implements OptionalSQLSegmentExtractor {
     
-    private final ColumnDefinitionExtractor columnDefinitionPhraseExtractor = new ColumnDefinitionExtractor();
+    private final ColumnDefinitionExtractor columnDefinitionExtractor = new ColumnDefinitionExtractor();
     
     @Override
     public Optional<ColumnDefinitionSegment> extract(final ParserRuleContext ancestorNode) {
@@ -41,17 +41,17 @@ public final class MySQLChangeColumnExtractor implements OptionalSQLSegmentExtra
         if (!changeColumnNode.isPresent()) {
             return Optional.absent();
         }
-        Optional<ParserRuleContext> oldColumnNode = ExtractorUtils.findFirstChildNode(changeColumnNode.get(), RuleName.COLUMN_NAME);
-        if (!oldColumnNode.isPresent()) {
+        Optional<ParserRuleContext> oldColumnNameNode = ExtractorUtils.findFirstChildNode(changeColumnNode.get(), RuleName.COLUMN_NAME);
+        if (!oldColumnNameNode.isPresent()) {
             return Optional.absent();
         }
         Optional<ParserRuleContext> columnDefinitionNode = ExtractorUtils.findFirstChildNode(changeColumnNode.get(), RuleName.COLUMN_DEFINITION);
         if (!columnDefinitionNode.isPresent()) {
             return Optional.absent();
         }
-        Optional<ColumnDefinitionSegment> result = columnDefinitionPhraseExtractor.extract(columnDefinitionNode.get());
+        Optional<ColumnDefinitionSegment> result = columnDefinitionExtractor.extract(columnDefinitionNode.get());
         if (result.isPresent()) {
-            result.get().setOldName(oldColumnNode.get().getText());
+            result.get().setOldName(oldColumnNameNode.get().getText());
             Optional<ColumnPositionSegment> columnPosition = new MySQLColumnPositionExtractor(result.get().getName()).extract(changeColumnNode.get());
             if (columnPosition.isPresent()) {
                 result.get().setPosition(columnPosition.get());

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLColumnPositionExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLColumnPositionExtractor.java
@@ -42,8 +42,7 @@ public final class MySQLColumnPositionExtractor implements OptionalSQLSegmentExt
             return Optional.absent();
         }
         Optional<ParserRuleContext> columnNameNode = ExtractorUtils.findFirstChildNode(firstOrAfterColumnNode.get(), RuleName.COLUMN_NAME);
-        ColumnPositionSegment result = new ColumnPositionSegment();
-        result.setStartIndex(firstOrAfterColumnNode.get().getStart().getStartIndex());
+        ColumnPositionSegment result = new ColumnPositionSegment(firstOrAfterColumnNode.get().getStart().getStartIndex());
         if (columnNameNode.isPresent()) {
             result.setColumnName(columnName);
             result.setAfterColumn(columnNameNode.get().getText());

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLDropIndexExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLDropIndexExtractor.java
@@ -41,7 +41,7 @@ public final class MySQLDropIndexExtractor implements CollectionSQLSegmentExtrac
     
     @Override
     public Collection<IndexSegment> extract(final ParserRuleContext ancestorNode) {
-        Collection<ParserRuleContext> dropIndexNodes = ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.DROP_INDEX_REF);
+        Collection<ParserRuleContext> dropIndexNodes = ExtractorUtils.getAllDescendantNodes(ancestorNode, RuleName.DROP_INDEX_DEF);
         if (dropIndexNodes.isEmpty()) {
             return Collections.emptyList();
         }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLModifyColumnExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/mysql/MySQLModifyColumnExtractor.java
@@ -31,10 +31,10 @@ import org.antlr.v4.runtime.ParserRuleContext;
 public final class MySQLModifyColumnExtractor extends ModifyColumnExtractor {
     
     @Override
-    protected void postExtractColumnDefinition(final ParserRuleContext ancestorNode, final ColumnDefinitionSegment columnDefinition) {
-        Optional<ColumnPositionSegment> columnPosition = new MySQLColumnPositionExtractor(columnDefinition.getName()).extract(ancestorNode);
-        if (columnPosition.isPresent()) {
-            columnDefinition.setPosition(columnPosition.get());
+    protected void postExtractColumnDefinition(final ParserRuleContext modifyColumnNode, final ColumnDefinitionSegment columnDefinition) {
+        Optional<ColumnPositionSegment> columnPositionSegment = new MySQLColumnPositionExtractor(columnDefinition.getName()).extract(modifyColumnNode);
+        if (columnPositionSegment.isPresent()) {
+            columnDefinition.setPosition(columnPositionSegment.get());
         }
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/sqlserver/SQLServerDropIndexExtractor.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/impl/dialect/sqlserver/SQLServerDropIndexExtractor.java
@@ -36,7 +36,7 @@ public final class SQLServerDropIndexExtractor implements OptionalSQLSegmentExtr
     
     @Override
     public Optional<IndexSegment> extract(final ParserRuleContext ancestorNode) {
-        Optional<ParserRuleContext> indexDefOptionNode = ExtractorUtils.findFirstChildNode(ancestorNode, RuleName.ALTER_DROP_INDEX);
+        Optional<ParserRuleContext> indexDefOptionNode = ExtractorUtils.findFirstChildNode(ancestorNode, RuleName.DROP_INDEX_DEF);
         if (!indexDefOptionNode.isPresent()) {
             return Optional.absent();
         }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/util/RuleName.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/extractor/util/RuleName.java
@@ -65,9 +65,7 @@ public enum RuleName {
     
     INDEX_NAME("IndexName"),
     
-    DROP_INDEX_REF("DropIndexDef"),
-    
-    ALTER_DROP_INDEX("AlterDropIndex"),
+    DROP_INDEX_DEF("DropIndexDef"),
     
     ADD_CONSTRAINT("AddConstraint"),
     

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/filler/impl/DropColumnFiller.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/filler/impl/DropColumnFiller.java
@@ -33,7 +33,6 @@ public final class DropColumnFiller implements SQLStatementFiller<DropColumnSegm
     
     @Override
     public void fill(final DropColumnSegment sqlSegment, final SQLStatement sqlStatement, final String sql, final ShardingRule shardingRule, final ShardingTableMetaData shardingTableMetaData) {
-        AlterTableStatement alterTableStatement = (AlterTableStatement) sqlStatement;
-        alterTableStatement.getDropColumnNames().addAll(sqlSegment.getDropColumnNames());
+        ((AlterTableStatement) sqlStatement).getDropColumnNames().add(sqlSegment.getColumnName());
     }
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/sql/segment/column/ColumnPositionSegment.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/sql/segment/column/ColumnPositionSegment.java
@@ -19,6 +19,7 @@ package io.shardingsphere.core.parsing.antlr.sql.segment.column;
 
 import io.shardingsphere.core.parsing.antlr.sql.segment.SQLSegment;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -26,11 +27,12 @@ import lombok.Setter;
  * 
  * @author duhongjun
  */
+@RequiredArgsConstructor
 @Getter
 @Setter
 public final class ColumnPositionSegment implements SQLSegment, Comparable<ColumnPositionSegment> {
     
-    private int startIndex;
+    private final int startIndex;
     
     private String firstColumn;
     

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/sql/segment/column/DropColumnSegment.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/antlr/sql/segment/column/DropColumnSegment.java
@@ -17,20 +17,20 @@
 
 package io.shardingsphere.core.parsing.antlr.sql.segment.column;
 
-import lombok.Getter;
-
-import java.util.Collection;
-import java.util.LinkedHashSet;
-
 import io.shardingsphere.core.parsing.antlr.sql.segment.SQLSegment;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Drop column segment.
  *
  * @author duhongjun
  */
+@RequiredArgsConstructor
 @Getter
+@EqualsAndHashCode
 public final class DropColumnSegment implements SQLSegment {
     
-    private final Collection<String> dropColumnNames = new LinkedHashSet<>();
+    private final String columnName;
 }

--- a/sharding-core/src/main/java/io/shardingsphere/core/parsing/parser/sql/SQLParserFactory.java
+++ b/sharding-core/src/main/java/io/shardingsphere/core/parsing/parser/sql/SQLParserFactory.java
@@ -99,7 +99,7 @@ public final class SQLParserFactory {
         lexerEngine.nextToken();
         TokenType secondaryTokenType = lexerEngine.getCurrentToken().getType();
         if (DCLStatement.isDCL(tokenType, secondaryTokenType)) {
-            return getDCLParser(dbType, tokenType, shardingRule, lexerEngine);
+            return new AntlrParsingEngine(dbType, sql, shardingRule, shardingTableMetaData);
         }
         if (DDLStatement.isDDL(tokenType, secondaryTokenType)) {
             return new AntlrParsingEngine(dbType, sql, shardingRule, shardingTableMetaData);

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/mysql/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/mysql/sql-statement-rule-definition.xml
@@ -3,7 +3,7 @@
     <sql-statement-rule context="createTable" sql-statement-class="io.shardingsphere.core.parsing.antlr.sql.statement.ddl.CreateTableStatement" 
                         extractor-rule-refs="tableNames, columnDefinitions, indexNames, outlinePrimaryKey" />
     <sql-statement-rule context="alterTable" sql-statement-class="io.shardingsphere.core.parsing.antlr.sql.statement.ddl.AlterTableStatement" 
-                        extractor-rule-refs="tableNames, outlinePrimaryKey, addColumn, dropColumn, changeColumn, modifyColumn, addIndex, dropIndex, renameIndex, dropPrimaryKey, renameTable" 
+                        extractor-rule-refs="tableNames, outlinePrimaryKey, addColumn, dropColumn, modifyColumn, changeColumn, addIndex, dropIndex, renameIndex, dropPrimaryKey, renameTable" 
                         optimizer-class="ddl.dialect.mysql.MySQLAlterTableOptimizer" />
     <sql-statement-rule context="dropTable" sql-statement-class="io.shardingsphere.core.parsing.antlr.sql.statement.ddl.DDLStatement" extractor-rule-refs="tableNames" />
     <sql-statement-rule context="truncateTable" sql-statement-class="io.shardingsphere.core.parsing.antlr.sql.statement.ddl.DDLStatement" extractor-rule-refs="tableName" />
@@ -19,7 +19,7 @@
     <sql-statement-rule context="rollback" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.rollback.RollbackStatement" />
     <sql-statement-rule context="setTransaction" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.set.transaction.SetTransactionStatement" />
     <sql-statement-rule context="savepoint" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.savepoint.SavepointStatement" />
-     
+    
     <sql-statement-rule context="grant" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
     <sql-statement-rule context="grantProxy" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
     <sql-statement-rule context="grantRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/mysql/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/mysql/sql-statement-rule-definition.xml
@@ -19,4 +19,24 @@
     <sql-statement-rule context="rollback" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.rollback.RollbackStatement" />
     <sql-statement-rule context="setTransaction" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.set.transaction.SetTransactionStatement" />
     <sql-statement-rule context="savepoint" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.savepoint.SavepointStatement" />
+     
+    <sql-statement-rule context="grant" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="grantProxy" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="grantRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="revoke" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="revokeAll" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="revokeProxy" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="revokeRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterCurrentUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUserRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="renameUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="setPassword" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="setDefaultRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUserRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="setRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
 </sql-statement-rule-definition>

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/oracle/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/oracle/sql-statement-rule-definition.xml
@@ -15,4 +15,13 @@
     <sql-statement-rule context="rollback" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.rollback.RollbackStatement" />
     <sql-statement-rule context="setTransaction" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.set.transaction.SetTransactionStatement" />
     <sql-statement-rule context="savepoint" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.savepoint.SavepointStatement" />
+    
+    <sql-statement-rule context="grant" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="revoke" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="createUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
 </sql-statement-rule-definition>

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/postgresql/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/postgresql/sql-statement-rule-definition.xml
@@ -20,4 +20,23 @@
     <sql-statement-rule context="show" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.ShowStatement" extractor-rule-refs="showParam" />
     <sql-statement-rule context="setParam" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.SetParamStatement" />
     <sql-statement-rule context="resetParam" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.ResetParamStatement" />
+    
+    <sql-statement-rule context="grant" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="grantRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="revoke" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="revokeRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="renameUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUserSetConfig" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUserResetConfig" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUserRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="renameRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterRoleSetConfig" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterRoleResetConfig" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
 </sql-statement-rule-definition>

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/postgresql/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/postgresql/sql-statement-rule-definition.xml
@@ -16,7 +16,7 @@
     <sql-statement-rule context="rollback" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.rollback.RollbackStatement" />
     <sql-statement-rule context="setTransaction" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.set.transaction.SetTransactionStatement" />
     <sql-statement-rule context="savepoint" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.savepoint.SavepointStatement" />
-
+    
     <sql-statement-rule context="show" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.ShowStatement" extractor-rule-refs="showParam" />
     <sql-statement-rule context="setParam" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.SetParamStatement" />
     <sql-statement-rule context="resetParam" sql-statement-class="io.shardingsphere.core.parsing.parser.dialect.postgresql.statement.ResetParamStatement" />

--- a/sharding-core/src/main/resources/META-INF/parsing-rule-definition/sqlserver/sql-statement-rule-definition.xml
+++ b/sharding-core/src/main/resources/META-INF/parsing-rule-definition/sqlserver/sql-statement-rule-definition.xml
@@ -17,4 +17,17 @@
     <sql-statement-rule context="rollback" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.rollback.RollbackStatement" />
     <sql-statement-rule context="setTransaction" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.set.transaction.SetTransactionStatement" />
     <sql-statement-rule context="savepoint" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.tcl.savepoint.SavepointStatement" />
+    
+    <sql-statement-rule context="grant" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="revoke" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="deny" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" extractor-rule-refs="tableNames" />
+    <sql-statement-rule context="createUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropUser" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createLogin" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterLogin" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropLogin" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="createRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="alterRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" />
+    <sql-statement-rule context="dropRole" sql-statement-class="io.shardingsphere.core.parsing.parser.sql.dcl.DCLStatement" /> 
 </sql-statement-rule-definition>


### PR DESCRIPTION
sharding.jdbc.config.sharding.props.sql.show= ...
sharding.jdbc.config.sharding.props.executor.size= ...
**Above config is valid but that is invalid in  v3.1.0.
When  i check the source code,I find the code have been changed and Official documents is not modified.**
##########################################################
V3.0.0：
**@ConfigurationProperties(prefix = "sharding.jdbc.config.sharding")**
public class SpringBootShardingRuleConfigurationProperties extends YamlShardingRuleConfiguration {
}

V3.1.0
**@ConfigurationProperties(prefix = "sharding.jdbc.config")**
public class SpringBootConfigMapConfigurationProperties {
}
    

